### PR TITLE
feat: 프로젝트 생성 페이지 헤더 제작 (#7)

### DIFF
--- a/src/components/project-editor/header/index.tsx
+++ b/src/components/project-editor/header/index.tsx
@@ -1,0 +1,111 @@
+import styled from 'styled-components';
+import React, { useState } from 'react';
+import theme from '@/styles/theme';
+import { HiChevronLeft } from 'react-icons/hi';
+import { FiEdit } from 'node_modules/react-icons/fi';
+import { Link, useLocation } from '@tanstack/react-router';
+
+const ProjectHeader = () => {
+  const [isEdit, setIsEdit] = useState(false);
+  const [projectTitle, setProjectTitle] = useState('새 프로젝트');
+  const onChangeProjectTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setProjectTitle(e.target.value);
+  };
+  const location = useLocation();
+  return (
+    <>
+      <S.HeaderContainer>
+        <S.HeaderLeftContents>
+          <Link to={'/dashboard'}>
+            <HiChevronLeft size={50} />
+          </Link>
+          <S.TitleBox>
+            {isEdit ? (
+              <S.ProjectTitle
+                value={projectTitle}
+                onChange={onChangeProjectTitle}
+              />
+            ) : (
+              <S.ViewText onClick={() => setIsEdit(true)}>
+                {projectTitle}
+              </S.ViewText>
+            )}
+            <FiEdit
+              color="white"
+              onClick={() => setIsEdit(!isEdit)}
+              size={30}
+            />
+          </S.TitleBox>
+        </S.HeaderLeftContents>
+        <S.ButtonBox>
+          {location.pathname.endsWith('/article') ? (
+            <>
+              <S.HeaderButton>기사 파일 업로드</S.HeaderButton>
+              <S.HeaderButton>템플릿 추천</S.HeaderButton>
+              <Link
+                to="/$project/avatar"
+                params={{ project: '1' }}>
+                <S.HeaderButton>템플릿 없이 진행하기</S.HeaderButton>
+              </Link>
+            </>
+          ) : (
+            <S.HeaderButton>제작하기</S.HeaderButton>
+          )}
+        </S.ButtonBox>
+      </S.HeaderContainer>
+    </>
+  );
+};
+
+export default ProjectHeader;
+
+const S = {
+  HeaderContainer: styled.div`
+    width: 100%;
+    height: 60px;
+    background-color: ${theme.colors.primary};
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    color: white;
+    svg {
+      cursor: pointer;
+      margin-left: ${theme.spacing.sm};
+    }
+  `,
+  HeaderLeftContents: styled.div`
+    display: flex;
+    align-items: center;
+  `,
+  TitleBox: styled.div`
+    width: 100%;
+    margin-left: 270px;
+    display: flex;
+    align-items: center;
+  `,
+
+  ProjectTitle: styled.input`
+    width: 100%;
+    background-color: theme.colors.white;
+    border: none;
+    outline: none;
+    color: theme.colors.black;
+    font-size: ${theme.fontSizes.fz30};
+  `,
+  ViewText: styled.span`
+    font-size: ${theme.fontSizes.fz30};
+  `,
+  ButtonBox: styled.div`
+    display: flex;
+    align-items: center;
+  `,
+
+  HeaderButton: styled.button`
+    background-color: ${theme.colors.white};
+    margin-right: ${theme.spacing.md};
+    border-radius: ${theme.radius.small};
+    padding: ${theme.spacing.sm} ${theme.spacing.md};
+    color: ${theme.colors.primary};
+    font-weight: ${theme.fontWeights.bold};
+  `,
+};

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -471,6 +471,16 @@ export const routeTree = rootRoute
         "/auth/sign-up/finish/"
       ]
     },
+    "/_projectSideBarLayout": {
+      "filePath": "_projectSideBarLayout.tsx",
+      "children": [
+        "/_projectSideBarLayout/$project/article/",
+        "/_projectSideBarLayout/$project/avatar/",
+        "/_projectSideBarLayout/$project/background/",
+        "/_projectSideBarLayout/$project/script/",
+        "/_projectSideBarLayout/$project/template/"
+      ]
+    },
     "/_sideBarLayout": {
       "filePath": "_sideBarLayout.tsx",
       "children": [

--- a/src/routes/_projectSideBarLayout.tsx
+++ b/src/routes/_projectSideBarLayout.tsx
@@ -11,6 +11,7 @@ import Avatar from '@/assets/projectIcon/avatar.svg?react';
 import Gallery from '@/assets/projectIcon/gallery.svg?react';
 import Script from '@/assets/projectIcon/script.svg?react';
 import theme from '@/styles/theme';
+import ProjectHeader from '@/components/project-editor/header';
 
 export const Route = createFileRoute('/_projectSideBarLayout')({
   component: RouteComponent,
@@ -20,68 +21,71 @@ function RouteComponent() {
   const id = '1';
   const matchRoute = useMatchRoute();
   return (
-    <S.ProjectLayout>
-      <S.ProjectSideBar>
-        <S.IconBox active={!!matchRoute({ to: '/$project/article' })}>
-          <Link
-            to="/$project/article"
-            params={{ project: id }}>
-            <Article
-              width={80}
-              height={60}
-            />
-            <p>기사 입력</p>
-          </Link>
-        </S.IconBox>
-        <S.IconBox active={!!matchRoute({ to: '/$project/template' })}>
-          <Link
-            to="/$project/template"
-            params={{ project: id }}>
-            <ChooseTemplate
-              width={80}
-              height={60}
-            />
-            <p>템플릿 선택</p>
-          </Link>
-        </S.IconBox>
-        <S.IconBox active={!!matchRoute({ to: '/$project/avatar' })}>
-          <Link
-            to="/$project/avatar"
-            params={{ project: id }}>
-            <Avatar
-              width={80}
-              height={60}
-            />
-            <p>아바타 선택</p>
-          </Link>
-        </S.IconBox>
-        <S.IconBox active={!!matchRoute({ to: '/$project/background' })}>
-          <Link
-            to="/$project/background"
-            params={{ project: id }}>
-            <Gallery
-              width={80}
-              height={60}
-            />
-            <p>배경 선택</p>
-          </Link>
-        </S.IconBox>
-        <S.IconBox active={!!matchRoute({ to: '/$project/script' })}>
-          <Link
-            to="/$project/script"
-            params={{ project: id }}>
-            <Script
-              width={80}
-              height={60}
-            />
-            <p>대사/자막</p>
-          </Link>
-        </S.IconBox>
-      </S.ProjectSideBar>
-      <Content>
-        <Outlet />
-      </Content>
-    </S.ProjectLayout>
+    <>
+      <ProjectHeader />
+      <S.ProjectLayout>
+        <S.ProjectSideBar>
+          <S.IconBox active={!!matchRoute({ to: '/$project/article' })}>
+            <Link
+              to="/$project/article"
+              params={{ project: id }}>
+              <Article
+                width={80}
+                height={60}
+              />
+              <p>기사 입력</p>
+            </Link>
+          </S.IconBox>
+          <S.IconBox active={!!matchRoute({ to: '/$project/template' })}>
+            <Link
+              to="/$project/template"
+              params={{ project: id }}>
+              <ChooseTemplate
+                width={80}
+                height={60}
+              />
+              <p>템플릿 선택</p>
+            </Link>
+          </S.IconBox>
+          <S.IconBox active={!!matchRoute({ to: '/$project/avatar' })}>
+            <Link
+              to="/$project/avatar"
+              params={{ project: id }}>
+              <Avatar
+                width={80}
+                height={60}
+              />
+              <p>아바타 선택</p>
+            </Link>
+          </S.IconBox>
+          <S.IconBox active={!!matchRoute({ to: '/$project/background' })}>
+            <Link
+              to="/$project/background"
+              params={{ project: id }}>
+              <Gallery
+                width={80}
+                height={60}
+              />
+              <p>배경 선택</p>
+            </Link>
+          </S.IconBox>
+          <S.IconBox active={!!matchRoute({ to: '/$project/script' })}>
+            <Link
+              to="/$project/script"
+              params={{ project: id }}>
+              <Script
+                width={80}
+                height={60}
+              />
+              <p>대사/자막</p>
+            </Link>
+          </S.IconBox>
+        </S.ProjectSideBar>
+        <Content>
+          <Outlet />
+        </Content>
+      </S.ProjectLayout>
+    </>
   );
 }
 


### PR DESCRIPTION
## ➕ 이슈 링크

- 이슈 넘버 #7 

## 🔎 작업 내용

- 프로젝트 에디터에서 사용하는 헤더 제작
   기사 입력 페이지일 경우 제작하기 버튼 대신 파일 업로드, 템플릿 추천, 템플릿 없이 진행하기 버튼 출력
   파일 업로드, 템플릿 추천 관련 로직은 추가 필요
   템플릿 없이 진행하기 버튼의 경우 아바타 선택 페이지로 이동하도록 설정
   (해당 버튼의 삭제 여부 논의 필요 사이드바에서 직접 클릭해서 진행하는 것은 어떠한지?)
  
## 💾 이미지 첨부
### 기사 입력 페이지일 경우
![image](https://github.com/user-attachments/assets/4ef17a23-f1e4-4ce9-9d34-b25c48c0bd9a)

### 프로젝트 이름 변경할 경우
![image](https://github.com/user-attachments/assets/25060399-bcdd-49e3-b95d-0b1c1169e43e)

### 기사 입력을 제외한 다른 에디터 페이지
![image](https://github.com/user-attachments/assets/ad84860f-b619-47db-9958-81d03244ffee)

## 🔧 리뷰 요구사항

디자인적인 부분들은 피그마에 와이어프레임 수정본이 올라오는 대로 다시...수정...해보도록...하겠습니다.....
기능적인 부분 및 코드 내 피드백이 필요한 부분이 있다면 적극적으로 리뷰 남겨주시면 감사하겠습니당
