### PR TITLE
feat: 회원가입시 사용하는 api 연동 구현 (#22)

### DIFF
--- a/src/api/login/api.ts
+++ b/src/api/login/api.ts
@@ -1,0 +1,30 @@
+import axios from "node_modules/axios";
+
+type loginProps = {
+    accessToken: string;
+    refreshToken: string;
+};
+
+export async function login(username: string, password: string): Promise<loginProps> {
+    try {
+        const response = await axios.post('/api/v1/auth/login', {
+            username: username,
+            password: password
+        });
+        const { accessToken, refreshToken } = response.data;
+        return { accessToken, refreshToken };
+
+    } catch (error: unknown) {
+        throw error;
+    }
+}
+
+export async function refresh(){
+    try {
+        const response = await axios.post('/api/v1/auth/refresh', null)
+        const { accessToken, refreshToken } = response.data;
+        return { accessToken, refreshToken };
+    } catch (error: unknown) {
+        throw error;
+    }
+}

--- a/src/api/sign-up/api.ts
+++ b/src/api/sign-up/api.ts
@@ -1,0 +1,111 @@
+import { BaseSchema, SignUpSchemaType } from "@/schema/SignUpSchema";
+import axios from "axios";
+
+
+
+export type RegistrationResult = {
+    success: boolean;
+    data?: any;
+    error?: any;
+};
+
+// 이메일 인증 코드 요청을 위한 API 호출 함수
+export async function checkEmailEffect(email: string): Promise<{ code?: string }> {
+    try {
+        const response = await axios.post('/api/v1/account/register/check-email', {
+            email: email
+        });
+
+        if (response.data && response.data.code) {
+            return { code: response.data.code }; 
+        } else {
+            return { code: undefined }; 
+        }
+    } catch (error: unknown) {
+        throw error; 
+    }
+}
+
+
+export async function VerifyEmailEffect(email: string, number: string): Promise<{ success: boolean; message?: string }> {
+    try {
+        const requestData = {
+            email: email,
+            code: number
+        };
+
+        const response = await axios.post('/api/v1/account/register/verify-email', requestData);
+        
+        return {
+            success: true,
+            message: response.data.message || '이메일 인증이 완료되었습니다.'
+        };
+    } catch (error: unknown) {
+        let message: string;
+        if (axios.isAxiosError(error) && error.response) {
+            message = error.response.data.message || '이메일 인증 처리 중 오류가 발생했습니다.';
+        } else {
+            message = '이메일 인증 처리 중 알 수 없는 오류가 발생했습니다.';
+        }
+
+        return {
+            success: false,
+            message: message
+        };
+    }
+}
+
+
+
+
+export const validateEmail = async (email: string) => {
+    console.log('이메일 유효성 검사 시작:', email);
+    
+    try {
+        const result = BaseSchema.pick({ email: true }).safeParse({ email });
+        if (!result.success) {
+            const formattedError = result.error.format();
+            const errorMessage = formattedError.email?._errors[0] || '이메일 형식이 올바르지 않습니다';
+            console.log('이메일 형식 오류:', errorMessage);
+            
+            return {
+                success: false,
+                error: errorMessage,
+            };
+        }
+        const checkResult = await checkEmailEffect(email);
+
+        if (typeof checkResult.code !== 'string') {
+            return {
+                success: false,
+                error: '인증 코드가 유효하지 않습니다',
+            };
+        }
+        return { 
+            success: true, 
+            error: null,
+            code: checkResult.code
+        };
+    } catch (error) {
+        console.error('이메일 검증 중 예상치 못한 오류:', error);
+        return { success: false, error: '알 수 없는 오류가 발생했습니다' };
+    }
+};
+
+
+export const registerUser = async (userData: SignUpSchemaType): Promise<RegistrationResult> => {
+    try {
+      const response = await axios.post('/api/v1/account/register', userData);
+      return {
+        success: true,
+        data: response.data
+      };
+    } catch (error: any) {
+      console.error('회원가입 실패:', error.response?.data);
+      console.error('오류 상태 코드:', error.response?.status);
+      return {
+        success: false,
+        error: error.response?.data?.message
+      };
+    }
+  };

--- a/src/components/auth/sign-in/agreement/index.tsx
+++ b/src/components/auth/sign-in/agreement/index.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react';
-import theme from '@/styles/theme';
 import styled from 'styled-components';
 import miniCheck from '@/assets/auth/mini-check.svg';
 import nMiniCheck from '@/assets/auth/mini-none-check.svg';
-
+import { TosModal } from '@/components/common/modal/tosModal';
+import theme from '@/styles/theme';
 type AgreementComponentType = {
   // eslint-disable-next-line no-unused-vars
   setIsChecked: (checked: boolean) => void;
@@ -13,18 +13,22 @@ type AgreementComponentType = {
     privacy: boolean;
     terms: boolean;
     marketing: boolean;
+    youtube: boolean;
   };
   // eslint-disable-next-line no-unused-vars
   onAgreementsChange: (agreements: {
     privacy: boolean;
     terms: boolean;
     marketing: boolean;
+    youtube: boolean;
   }) => void;
 };
 
 type StyledProps = {
   $isChecked?: boolean;
 };
+
+type ModalType = 'privacy' | 'terms' | 'marketing' | 'youtube' | null;
 
 export const AgreeComponent = ({
   setIsChecked,
@@ -37,41 +41,124 @@ export const AgreeComponent = ({
       privacy: false,
       terms: false,
       marketing: false,
+      youtube: false,
     }
   );
+  const [showModal, setShowModal] = useState<ModalType>(null);
+  const [modalQueue, setModalQueue] = useState<ModalType[]>([]);
 
   function handleAllAgree() {
-    const newValue = !isAllChecked();
-    setIsChecked(newValue);
+    // 아직 동의하지 않은 약관들을 큐에 넣습니다
+    const pendingAgreements: ModalType[] = [];
+    if (!agreements.privacy) pendingAgreements.push('privacy');
+    if (!agreements.terms) pendingAgreements.push('terms');
+    if (!agreements.marketing) pendingAgreements.push('marketing');
+    if (!agreements.youtube) pendingAgreements.push('youtube');
 
-    const newAgreements = {
-      privacy: newValue,
-      terms: newValue,
-      marketing: newValue,
-    };
+    if (pendingAgreements.length === 0) {
+      // 이미 모든 항목이 체크되어 있는 경우 해제 가능하도록 합니다
+      const newValue = false;
+      setIsChecked(newValue);
 
-    setAgreements(newAgreements);
-    onAgreementsChange(newAgreements);
+      const newAgreements = {
+        privacy: newValue,
+        terms: newValue,
+        marketing: newValue,
+        youtube: newValue,
+      };
+
+      setAgreements(newAgreements);
+      onAgreementsChange(newAgreements);
+    } else {
+      // 아직 동의하지 않은 약관이 있으면 큐에 넣고 첫 번째 약관 모달을 엽니다
+      setModalQueue(pendingAgreements);
+      setShowModal(pendingAgreements[0]);
+    }
   }
 
-  function handleSingleAgree(key: 'privacy' | 'terms' | 'marketing') {
+  function openModal(type: ModalType) {
+    setShowModal(type);
+  }
+
+  function closeModal() {
+    setShowModal(null);
+
+    // 큐에서 현재 모달을 제거하고, 다음 모달이 있으면 엽니다
+    if (modalQueue.length > 0) {
+      const newQueue = [...modalQueue];
+      newQueue.shift(); // 첫 번째 항목 제거
+      setModalQueue(newQueue);
+
+      if (newQueue.length > 0) {
+        setShowModal(newQueue[0]); // 다음 모달 표시
+      }
+    }
+  }
+
+  function handleAgreementItemClick(type: ModalType) {
+    // type이 null이 아닌지 확인
+    if (type === null) return;
+
+    // 이미 동의된 상태라면 바로 체크 해제
+    if (agreements[type]) {
+      const newAgreements = {
+        ...agreements,
+        [type]: false,
+      };
+      setAgreements(newAgreements);
+      onAgreementsChange(newAgreements);
+
+      // 전체 동의 체크박스 상태 업데이트
+      setIsChecked(false);
+    } else {
+      // 동의되지 않은 상태라면 모달 표시
+      openModal(type);
+    }
+  }
+
+  function handleModalAgree() {
+    if (!showModal) return;
+
     const newAgreements = {
       ...agreements,
-      [key]: !agreements[key],
+      [showModal]: true,
     };
 
     setAgreements(newAgreements);
     onAgreementsChange(newAgreements);
 
+    // 모든 항목이 체크되었는지 확인
     const allChecked = Object.values(newAgreements).every(
       (value) => value === true
     );
     setIsChecked(allChecked);
+
+    closeModal(); // 이 함수는 이제 다음 모달이 있으면 자동으로 엽니다
+  }
+
+  function handleModalDisagree() {
+    if (!showModal) return;
+
+    const newAgreements = {
+      ...agreements,
+      [showModal]: false,
+    };
+
+    setAgreements(newAgreements);
+    onAgreementsChange(newAgreements);
+
+    // 모달 큐를 비웁니다 (전체 동의 프로세스 중단)
+    setModalQueue([]);
+    closeModal();
   }
 
   function isAllChecked() {
     return Object.values(agreements).every((value) => value === true);
   }
+
+  const handleYoutubeConnect = () => {
+    handleModalAgree();
+  };
 
   useEffect(() => {
     function checkRequiredAgreements() {
@@ -80,6 +167,58 @@ export const AgreeComponent = ({
 
     onRequiredAgreementChange(checkRequiredAgreements());
   }, [agreements, onRequiredAgreementChange]);
+
+  useEffect(() => {
+    const handleEscKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && showModal) {
+        setModalQueue([]);
+        setShowModal(null);
+      }
+    };
+    window.addEventListener('keydown', handleEscKey);
+
+    return () => {
+      window.removeEventListener('keydown', handleEscKey);
+    };
+  }, [showModal]);
+
+  // 각 약관 유형에 맞는 모달 메시지 및 타입을 반환하는 함수
+  const getModalContent = (type: ModalType) => {
+    switch (type) {
+      case 'privacy':
+        return {
+          title: '[필수] 개인정보처리방침',
+          message: '개인정보처리방침에 관한 내용입니다. 동의하시겠습니까?',
+          type: 'normal',
+        };
+      case 'terms':
+        return {
+          title: '[필수] 이용약관',
+          message: '이용약관에 관한 내용입니다. 동의하시겠습니까?',
+          type: 'normal',
+        };
+      case 'marketing':
+        return {
+          title: '[선택] 마케팅 이용 동의',
+          message:
+            '마케팅 이용에 동의하시면 다양한 이벤트 정보를 받아보실 수 있습니다. 동의하시겠습니까?',
+          type: 'normal',
+        };
+      case 'youtube':
+        return {
+          title: '[선택] 유튜브 계정 연동',
+          message:
+            '유튜브 계정 연동에 동의하시면 서비스를 더 풍부하게 이용하실 수 있습니다.',
+          type: 'youtube',
+        };
+      default:
+        return {
+          title: '',
+          message: '',
+          type: 'normal',
+        };
+    }
+  };
 
   return (
     <>
@@ -102,7 +241,7 @@ export const AgreeComponent = ({
 
         <S.SelectionList>
           <S.SelectionItem
-            onClick={() => handleSingleAgree('privacy')}
+            onClick={() => handleAgreementItemClick('privacy')}
             $isChecked={agreements.privacy}>
             {agreements.privacy ? (
               <img
@@ -119,7 +258,7 @@ export const AgreeComponent = ({
           </S.SelectionItem>
 
           <S.SelectionItem
-            onClick={() => handleSingleAgree('terms')}
+            onClick={() => handleAgreementItemClick('terms')}
             $isChecked={agreements.terms}>
             {agreements.terms ? (
               <img
@@ -136,7 +275,7 @@ export const AgreeComponent = ({
           </S.SelectionItem>
 
           <S.SelectionItem
-            onClick={() => handleSingleAgree('marketing')}
+            onClick={() => handleAgreementItemClick('marketing')}
             $isChecked={agreements.marketing}>
             {agreements.marketing ? (
               <img
@@ -151,8 +290,38 @@ export const AgreeComponent = ({
             )}
             <p>[선택] 마케팅 이용 동의</p>
           </S.SelectionItem>
+
+          <S.SelectionItem
+            onClick={() => handleAgreementItemClick('youtube')}
+            $isChecked={agreements.youtube}>
+            {agreements.youtube ? (
+              <img
+                src={miniCheck}
+                alt="mini-check-active"
+              />
+            ) : (
+              <img
+                src={nMiniCheck}
+                alt="mini-check-none-active"
+              />
+            )}
+            <p>[선택] 유튜브 계정 연동 동의</p>
+          </S.SelectionItem>
         </S.SelectionList>
       </S.AgreementWrapper>
+
+      {/* 모달 컴포넌트 */}
+      {showModal && (
+        <TosModal
+          type={getModalContent(showModal).type as 'normal' | 'youtube'}
+          title={getModalContent(showModal).title}
+          message={getModalContent(showModal).message}
+          onAgree={handleModalAgree}
+          onDisagree={handleModalDisagree}
+          onClose={closeModal}
+          onYoutubeConnect={handleYoutubeConnect}
+        />
+      )}
     </>
   );
 };

--- a/src/components/auth/sign-in/info/index.tsx
+++ b/src/components/auth/sign-in/info/index.tsx
@@ -3,72 +3,71 @@ import styled from 'styled-components';
 import { useState, ChangeEvent, useEffect } from 'react';
 import {
   SignUpSchemaType,
-  BaseSchema,
   validateEmail,
-  validateNickname,
 } from '@/schema/SignUpSchema';
 import { validateField } from '@/utils/validation';
-import { ZodError } from 'zod';
+import { VerifyEmailEffect } from '@/api/sign-up/api';
 
 type InfoComponentProps = {
-  // eslint-disable-next-line no-unused-vars
+  formData: SignUpSchemaType;
+  onInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   setIsCheckInfo: (verified: boolean) => void;
+  setFormData: React.Dispatch<React.SetStateAction<SignUpSchemaType>>;
 };
 
-export const InfoComponent = ({ setIsCheckInfo }: InfoComponentProps) => {
-  const [formData, setFormData] = useState<SignUpSchemaType>({
-    nickname: '',
-    email: '',
-    password: '',
-    checkPassword: '',
-  });
-
+export const InfoComponent = ({ formData, onInputChange, setIsCheckInfo }: InfoComponentProps) => {
   const [errors, setErrors] = useState<{
-    nickname?: string;
     email?: string;
+    code?: string;
     password?: string;
     checkPassword?: string;
   }>({});
 
   const [isChecking, setIsChecking] = useState({
-    nickname: false,
     email: false,
   });
 
   const [isVerified, setIsVerified] = useState({
-    nickname: false,
     email: false,
   });
 
+  // 이메일 인증 상태를 추가
+  const [emailVerificationStatus, setEmailVerificationStatus] = useState<'idle' | 'verifying' | 'verified'>('idle');
+
+  // 이메일 확인번호 컴포넌트 표시 상태
+  const [showVerificationCode, setShowVerificationCode] = useState(false);
+
   const [validationStatus, setValidationStatus] = useState({
-    nickname: false,
     email: false,
     password: false,
     checkPassword: false,
   });
 
+  const [checkPassword, setCheckPassword] = useState('');
+
   useEffect(() => {
     const allFieldsValid = Object.values(validationStatus).every(
       (status) => status
     );
-    const allVerified = isVerified.nickname && isVerified.email;
+    const allVerified = isVerified.email;
+    const passwordValid = validationStatus.password && validationStatus.checkPassword;
 
-    // 모든 필드가 유효하고 닉네임과 이메일이 중복 확인된 경우에만 완료
-    setIsCheckInfo(allFieldsValid && allVerified);
+    // 모든 필드가 유효하고 이메일이 인증된 경우에만 완료
+    setIsCheckInfo(allFieldsValid && allVerified && passwordValid);
   }, [validationStatus, isVerified, setIsCheckInfo]);
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
-    setFormData((prev) => ({
-      ...prev,
-      [name]: value,
-    }));
 
-    if (name === 'nickname' || name === 'email') {
-      setIsVerified((prev) => ({
-        ...prev,
-        [name]: false,
-      }));
+    // 부모 컴포넌트의 formData 업데이트 (checkPassword 제외)
+    if (name !== 'checkPassword') {
+      onInputChange(e);
+    }
+
+    // 이메일이 변경되면 인증 상태 초기화
+    if (name === 'email') {
+      setEmailVerificationStatus('idle');
+      setShowVerificationCode(false);
     }
 
     const validationResult = validateField(name, value, formData);
@@ -77,11 +76,11 @@ export const InfoComponent = ({ setIsCheckInfo }: InfoComponentProps) => {
       [name]: validationResult.error,
     }));
 
-    // 해당 필드의 유효성 검사 상태 업데이트
-    if (name === 'password' && formData.checkPassword) {
+    // 비밀번호 유효성 검사
+    if (name === 'password' && checkPassword) {
       const checkPasswordResult = validateField(
         'checkPassword',
-        formData.checkPassword,
+        checkPassword,
         {
           ...formData,
           password: value,
@@ -96,7 +95,7 @@ export const InfoComponent = ({ setIsCheckInfo }: InfoComponentProps) => {
       setValidationStatus((prev) => ({
         ...prev,
         checkPassword:
-          !checkPasswordResult.error && Boolean(formData.checkPassword),
+          !checkPasswordResult.error && Boolean(checkPassword),
       }));
     }
 
@@ -106,54 +105,26 @@ export const InfoComponent = ({ setIsCheckInfo }: InfoComponentProps) => {
     }));
   };
 
-  // 닉네임 중복 확인
-  const handleNicknameCheck = async () => {
-    if (!formData.nickname) {
-      setErrors((prev) => ({
-        ...prev,
-        nickname: '닉네임을 입력해주세요',
-      }));
-      return;
-    }
+  const handleCheckPasswordChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setCheckPassword(value);
 
-    setIsChecking((prev) => ({ ...prev, nickname: true }));
+    const validationResult = validateField('checkPassword', value, {
+      ...formData,
+      password: formData.password,
+    });
 
-    try {
-      // baseSchema를 사용하여 닉네임 부분만 유효성 검사
-      await BaseSchema.pick({ nickname: true }).parseAsync({
-        nickname: formData.nickname,
-      });
+    setErrors((prev) => ({
+      ...prev,
+      checkPassword: validationResult.error,
+    }));
 
-      // 닉네임 중복 검사 로직
-      const result = await validateNickname(formData.nickname);
-      if (result.success) {
-        setErrors((prev) => ({ ...prev, nickname: undefined }));
-        setValidationStatus((prev) => ({ ...prev, nickname: true }));
-        setIsVerified((prev) => ({ ...prev, nickname: true }));
-        alert('사용 가능한 닉네임입니다.');
-      } else {
-        setErrors((prev) => ({ ...prev, nickname: result.error as string }));
-        setValidationStatus((prev) => ({ ...prev, nickname: false }));
-        setIsVerified((prev) => ({ ...prev, nickname: false }));
-      }
-    } catch (error) {
-      const zodError = error as {
-        formErrors?: { fieldErrors?: { nickname?: string[] } };
-      };
-      if (zodError?.formErrors?.fieldErrors?.nickname?.[0]) {
-        setErrors((prev) => ({
-          ...prev,
-          nickname: zodError.formErrors!.fieldErrors!.nickname![0],
-        }));
-        setValidationStatus((prev) => ({ ...prev, nickname: false }));
-        setIsVerified((prev) => ({ ...prev, nickname: false }));
-      }
-    } finally {
-      setIsChecking((prev) => ({ ...prev, nickname: false }));
-    }
+    setValidationStatus((prev) => ({
+      ...prev,
+      checkPassword: !validationResult.error && Boolean(value),
+    }));
   };
 
-  // 이메일 중복 확인
   const handleEmailCheck = async () => {
     if (!formData.email) {
       setErrors((prev) => ({
@@ -164,80 +135,91 @@ export const InfoComponent = ({ setIsCheckInfo }: InfoComponentProps) => {
     }
 
     setIsChecking((prev) => ({ ...prev, email: true }));
-
     try {
-      // baseSchema를 사용하여 이메일 부분만 유효성 검사
-      await BaseSchema.pick({ email: true }).parseAsync({
-        email: formData.email,
-      });
-
-      // 이메일 중복 검사 로직
       const result = await validateEmail(formData.email);
+
       if (result.success) {
         setErrors((prev) => ({ ...prev, email: undefined }));
         setValidationStatus((prev) => ({ ...prev, email: true }));
         setIsVerified((prev) => ({ ...prev, email: true }));
-        alert('사용 가능한 이메일입니다.');
+
+        setShowVerificationCode(true);
       } else {
         setErrors((prev) => ({ ...prev, email: result.error as string }));
         setValidationStatus((prev) => ({ ...prev, email: false }));
         setIsVerified((prev) => ({ ...prev, email: false }));
       }
-    } catch (error: unknown) {
-      if (error instanceof ZodError) {
-        const emailErrors = error.formErrors?.fieldErrors?.email;
-        if (emailErrors && emailErrors.length > 0) {
-          setErrors((prev) => ({
-            ...prev,
-            email: emailErrors[0],
-          }));
-          setValidationStatus((prev) => ({ ...prev, email: false }));
-          setIsVerified((prev) => ({ ...prev, email: false }));
-        }
-      }
+    } catch (error) {
+      console.error('이메일 검증 중 오류 발생:', error);
+      setErrors((prev) => ({
+        ...prev,
+        email: '알 수 없는 오류가 발생했습니다',
+      }));
+      setValidationStatus((prev) => ({ ...prev, email: false }));
+      setIsVerified((prev) => ({ ...prev, email: false }));
+    } finally {
+      setIsChecking((prev) => ({ ...prev, email: false }));
     }
+  };
+
+  const handleVerifyEmail = async (email: string, number: string) => {
+    setEmailVerificationStatus('verifying');
+
+    try {
+      const result = await VerifyEmailEffect(email, number);
+
+      if (result.success) {
+        setEmailVerificationStatus('verified');
+        setIsVerified((prev) => ({ ...prev, email: true }));
+        setErrors((prev) => ({ ...prev, code: undefined }));
+        setShowVerificationCode(false);
+      } else {
+        setEmailVerificationStatus('idle');
+        setErrors((prev) => ({ ...prev, code: result.message }));
+      }
+    } catch (error) {
+      setEmailVerificationStatus('idle');
+      setErrors((prev) => ({ ...prev, code: '인증 처리 중 오류가 발생했습니다' }));
+      console.error('이메일 인증 처리 중 오류:', error);
+    }
+  };
+
+  const getVerifyButtonText = () => {
+    if (emailVerificationStatus === 'verifying') {
+      return '인증 중';
+    } else if (emailVerificationStatus === 'verified') {
+      return '인증 완료';
+    } else {
+      return '이메일 인증';
+    }
+  };
+
+  const VerifyButton = ({ onClick, disabled, children }: { onClick: () => void; disabled?: boolean; children: React.ReactNode }) => {
+    return (
+      <S.VerifyButton onClick={onClick} disabled={disabled}>
+        {children}
+      </S.VerifyButton>
+    );
   };
   return (
     <>
       <h2>회원정보를 설정해주세요</h2>
       <S.InfoWrapper>
         <S.InfoSetupContainer>
-          <S.InputSet>
-            <S.Row>
-              <S.Label>닉네임</S.Label>
-              <S.Duplicate
-                onClick={handleNicknameCheck}
-                disabled={isChecking.nickname}>
-                {isChecking.nickname
-                  ? '확인 중...'
-                  : isVerified.nickname
-                    ? '확인 완료'
-                    : '중복 확인'}
-              </S.Duplicate>
-            </S.Row>
-            <S.Input
-              type="text"
-              name="nickname"
-              value={formData.nickname}
-              onChange={handleInputChange}
-              placeholder="닉네임을 입력해주세요"
-            />
-            {errors.nickname && (
-              <S.ErrorMessage>{errors.nickname}</S.ErrorMessage>
-            )}
-          </S.InputSet>
 
           <S.InputSet>
             <S.Row>
               <S.Label>이메일</S.Label>
               <S.Duplicate
                 onClick={handleEmailCheck}
-                disabled={isChecking.email}>
-                {isChecking.email
-                  ? '확인 중...'
-                  : isVerified.email
-                    ? '인증 완료'
-                    : '이메일 인증'}
+                disabled={isChecking.email || emailVerificationStatus === 'verifying' || emailVerificationStatus === 'verified'}>
+                {emailVerificationStatus === 'verified' 
+                  ? '인증 완료' 
+                  : emailVerificationStatus === 'verifying'
+                    ? '인증 중'
+                    : isChecking.email
+                      ? '확인 중...'
+                      : '이메일 인증'}
               </S.Duplicate>
             </S.Row>
             <S.Input
@@ -246,9 +228,34 @@ export const InfoComponent = ({ setIsCheckInfo }: InfoComponentProps) => {
               value={formData.email}
               onChange={handleInputChange}
               placeholder="이메일을 입력해주세요"
+              disabled={emailVerificationStatus === 'verified'}
             />
             {errors.email && <S.ErrorMessage>{errors.email}</S.ErrorMessage>}
           </S.InputSet>
+
+          {/* 이메일 인증 버튼을 누른 후에만 확인번호 입력 필드 표시 */}
+          {showVerificationCode && emailVerificationStatus !== 'verified' && (
+            <S.InputSet>
+              <S.Row>
+                <S.Label>이메일 확인 번호</S.Label>
+              </S.Row>
+              <S.CodeVerificationContainer>
+                <S.Input
+                  type="text"
+                  name="code"
+                  value={formData.code}
+                  onChange={handleInputChange}
+                  placeholder="이메일 확인 번호를 입력해주세요"
+                />
+                <VerifyButton 
+                  onClick={() => handleVerifyEmail(formData.email, formData.code)}
+                  disabled={emailVerificationStatus === 'verifying'}>
+                  {getVerifyButtonText()}
+                </VerifyButton>
+              </S.CodeVerificationContainer>
+              {errors.code && <S.ErrorMessage>{errors.code}</S.ErrorMessage>}
+            </S.InputSet>
+          )}
 
           <S.InputSet>
             <S.Row>
@@ -273,8 +280,8 @@ export const InfoComponent = ({ setIsCheckInfo }: InfoComponentProps) => {
             <S.Input
               type="password"
               name="checkPassword"
-              value={formData.checkPassword}
-              onChange={handleInputChange}
+              value={checkPassword}
+              onChange={handleCheckPasswordChange}
               placeholder="다시 한번 비밀번호을 입력해주세요"
             />
             {errors.checkPassword && (
@@ -299,7 +306,7 @@ const S = {
   InfoSetupContainer: styled.div`
     width: 75%;
     height: auto;
-    min-height: 49vh;
+    min-height: 43vh;
     padding: 2vh 1.5vw;
     background-color: ${theme.colors.background};
     border-radius: ${theme.radius.medium};
@@ -345,6 +352,34 @@ const S = {
       cursor: not-allowed;
     }
   `,
+
+   CodeVerificationContainer: styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+`,
+ VerifyButton: styled.button`
+  padding: 8px 16px;
+  background-color: #4a90e2;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background-color 0.3s;
+  white-space: nowrap;
+
+  &:hover {
+    background-color: #357abD;
+  }
+
+  &:disabled {
+    background-color: #cccccc;
+    cursor: not-allowed;
+  }
+  `,
+
   Row: styled.div`
     display: flex;
     justify-content: space-between;

--- a/src/components/auth/sign-in/phone/index.tsx
+++ b/src/components/auth/sign-in/phone/index.tsx
@@ -3,21 +3,27 @@ import styled from 'styled-components';
 import { useState, ChangeEvent } from 'react';
 
 type PhoneComponentProps = {
-  // eslint-disable-next-line no-unused-vars
+  formData: {
+    name?: string | undefined;
+    phone?: string | undefined;
+  };
+  onInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   setIsCheckPhone: (verified: boolean) => void;
 };
 
-export const PhoneComponent = ({ setIsCheckPhone }: PhoneComponentProps) => {
+export const PhoneComponent = ({ onInputChange, setIsCheckPhone }: PhoneComponentProps) => {
   const [name, setName] = useState('');
-  const [phoneNumber, setPhoneNumber] = useState('');
+  const [phone, setPhone] = useState('');
   const [isVerified, setIsVerified] = useState(false);
 
   const handleNameChange = (e: ChangeEvent<HTMLInputElement>) => {
     setName(e.target.value);
+    onInputChange(e);
   };
 
   const handlePhoneChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setPhoneNumber(e.target.value);
+    setPhone(e.target.value);
+    onInputChange(e);
   };
 
   const handleVerification = () => {
@@ -36,6 +42,7 @@ export const PhoneComponent = ({ setIsCheckPhone }: PhoneComponentProps) => {
             </S.Row>
             <S.Input
               type="text"
+              name="name"
               value={name}
               onChange={handleNameChange}
               placeholder="이름을 입력해주세요"
@@ -48,7 +55,8 @@ export const PhoneComponent = ({ setIsCheckPhone }: PhoneComponentProps) => {
             </S.Row>
             <S.Input
               type="text"
-              value={phoneNumber}
+              name="phone"
+              value={phone}
               onChange={handlePhoneChange}
               placeholder="휴대폰 번호를 입력해주세요"
               maxLength={11}

--- a/src/routes/auth/login/index.tsx
+++ b/src/routes/auth/login/index.tsx
@@ -13,6 +13,7 @@ import LinkButton from '@/components/common/button/linkButton';
 import { useForm, Controller } from 'react-hook-form';
 import { LoginSchema, type LoginSchemaType } from '@/schema/LoginSchema';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { login } from '@/api/login/api';
 export const Route = createFileRoute('/auth/login/')({
   component: RouteComponent,
 });
@@ -41,11 +42,19 @@ function RouteComponent() {
     setIsChecked(!isChecked);
   }
 
-  // 로그인 API 호출
-  const onSubmit = (data: LoginSchemaType) => {
-    // eslint-disable-next-line no-console
-    console.log(data);
-  };
+// 로그인 API 호출
+const onSubmit = async (data: LoginSchemaType) => {
+  // eslint-disable-next-line no-console
+  console.log(data);
+
+  try {
+      const { accessToken, refreshToken } = await login(data.email, data.password);
+      console.log(accessToken, refreshToken);
+  } catch (error) {
+      console.error('로그인 실패:', error);
+  }
+  
+};
 
   return (
     <S.LoginWrapper>

--- a/src/routes/auth/sign-in/index.tsx
+++ b/src/routes/auth/sign-in/index.tsx
@@ -12,6 +12,8 @@ import { VscTriangleLeft } from 'react-icons/vsc';
 import AgreeComponent from '@/components/auth/sign-in/agreement';
 import PhoneComponent from '@/components/auth/sign-in/phone';
 import InfoComponent from '@/components/auth/sign-in/info';
+import { SignUpSchemaType } from '@/schema/SignUpSchema';
+import { registerUser } from '@/api/sign-up/api';
 
 export const Route = createFileRoute('/auth/sign-in/')({
   component: RouteComponent,
@@ -26,20 +28,30 @@ type StyledProps = {
 
 function RouteComponent() {
   const navigate = useNavigate();
+
   const [isChecked, setIsChecked] = useState(false);
   const [isPhoned, setIsPhoned] = useState(false);
   const [isLocked, setIsLocked] = useState(false);
   const [isCheckPhone, setIsCheckPhone] = useState(false);
   const [isCheckInfo, setIsCheckInfo] = useState(false);
+  const [formData, setFormData] = useState<SignUpSchemaType>({
+    nickname: '',
+    email: '',
+    password: '',
+    code: '',
+    name: '',
+    phone: '',
+});
+
   // eslint-disable-next-line no-console
   console.log(isChecked, isPhoned, isLocked);
-  const [requiredAgreementsChecked, setRequiredAgreementsChecked] =
-    useState(false);
-
+  
+  const [requiredAgreementsChecked, setRequiredAgreementsChecked] = useState(false);
   const [agreements, setAgreements] = useState({
     privacy: false,
     terms: false,
     marketing: false,
+    youtube: false,
   });
 
   const [currentStep, setCurrentStep] = useState(0);
@@ -48,11 +60,20 @@ function RouteComponent() {
     privacy: boolean;
     terms: boolean;
     marketing: boolean;
+    youtube: boolean;
   }) {
     setAgreements(newAgreements);
   }
 
-  const goToNext = () => {
+  function handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const { name, value } = e.target;
+    setFormData((prevData) => ({
+      ...prevData,
+      [name]: value,
+    }));
+  }
+
+  const goToNext = async () => {
     if (currentStep === 0 && requiredAgreementsChecked) {
       setCurrentStep(1);
       setIsPhoned(true);
@@ -60,7 +81,18 @@ function RouteComponent() {
       setCurrentStep(2);
       setIsLocked(true);
     } else if (currentStep === 2 && isCheckInfo) {
-      navigate({ to: '/auth/sign-up/finish' });
+      console.log("Submitting form data:", formData);
+      try {
+        const result = await registerUser(formData);
+        if (result.success) {
+          navigate({ to: '/auth/sign-up/finish' });
+        } else {
+          console.error(result.error)
+        }
+      } catch (error) {
+        console.error("Registration error:", error);
+
+      }
     }
   };
 
@@ -97,10 +129,24 @@ function RouteComponent() {
         />
       );
     } else if (currentStep === 1) {
-      return <PhoneComponent setIsCheckPhone={handlePhoneVerification} />;
+      return (
+        <PhoneComponent
+          formData={formData}
+          onInputChange={handleInputChange}
+          setIsCheckPhone={handlePhoneVerification}
+        />
+      );
     } else if (currentStep === 2) {
-      return <InfoComponent setIsCheckInfo={handleInfoVerification} />;
+      return (
+        <InfoComponent
+          formData={formData}
+          onInputChange={handleInputChange}
+          setIsCheckInfo={handleInfoVerification}
+          setFormData={setFormData} // Pass setFormData to InfoComponent
+        />
+      );
     }
+    return null;
   };
 
   const renderButtons = () => {
@@ -110,7 +156,8 @@ function RouteComponent() {
           $inGroup={false}
           onClick={goToNext}
           disabled={!requiredAgreementsChecked}
-          $isActive={requiredAgreementsChecked}>
+          $isActive={requiredAgreementsChecked}
+        >
           <p>다음</p>
         </S.NextButtonContainer>
       );
@@ -127,7 +174,8 @@ function RouteComponent() {
             disabled={
               (currentStep === 1 && !isCheckPhone) ||
               (currentStep === 2 && !isCheckInfo)
-            }>
+            }
+          >
             <p>{currentStep === 2 ? '완료' : '다음'}</p>
           </S.NextButtonContainer>
         </S.ButtonGroup>

--- a/src/schema/SignUpSchema.ts
+++ b/src/schema/SignUpSchema.ts
@@ -1,21 +1,15 @@
 /* eslint-disable @typescript-eslint/no-unused-vars, no-unused-vars */
 import { z } from 'zod';
+import {checkEmailEffect } from '@/api/sign-up/api';
 
-async function checkNicknameDuplicate(nickname: string): Promise<boolean> {
-  // 닉네임 중복 API 호출 구현 예정
-  return false;
-}
-
-async function checkEmailDuplicate(email: string): Promise<boolean> {
-  // 이메일 중복 API 호출 구현 예정
-  return false;
-}
 
 export type SignUpSchemaType = {
+  code: string;
   nickname: string;
   email: string;
   password: string;
-  checkPassword: string;
+  name?: string | undefined;
+  phone?: string | undefined;
 };
 
 export const BaseSchema = z.object({
@@ -41,33 +35,6 @@ export const SignUpSchema = BaseSchema.refine(
   }
 );
 
-export const validateNickname = async (nickname: string) => {
-  try {
-    const result = BaseSchema.pick({ nickname: true }).safeParse({ nickname });
-    if (!result.success) {
-      const formattedError = result.error.format();
-      return {
-        success: false,
-        error:
-          formattedError.nickname?._errors[0] ||
-          '닉네임 형식이 올바르지 않습니다',
-      };
-    }
-
-    const isDuplicate = await checkNicknameDuplicate(nickname);
-    if (isDuplicate) {
-      return {
-        success: false,
-        error: '이미 사용 중인 닉네임입니다',
-      };
-    }
-
-    return { success: true, error: null };
-  } catch (error) {
-    return { success: false, error: '알 수 없는 오류가 발생했습니다' };
-  }
-};
-
 export const validateEmail = async (email: string) => {
   try {
     const result = BaseSchema.pick({ email: true }).safeParse({ email });
@@ -80,15 +47,8 @@ export const validateEmail = async (email: string) => {
       };
     }
 
-    const isDuplicate = await checkEmailDuplicate(email);
-    if (isDuplicate) {
-      return {
-        success: false,
-        error: '이미 가입된 이메일입니다',
-      };
-    }
-
-    return { success: true, error: null };
+    const code = await checkEmailEffect(email);
+    return { success: true, error: null, code: code };
   } catch (error) {
     return { success: false, error: '알 수 없는 오류가 발생했습니다' };
   }
@@ -124,6 +84,7 @@ export const validateSignUpSchema = async (data: SignUpSchemaType) => {
       return { success: false, error: formResult.error.format() };
     }
 
+    /*
     const nicknameResult = await checkNicknameDuplicate(data.nickname);
     if (nicknameResult) {
       return {
@@ -143,6 +104,7 @@ export const validateSignUpSchema = async (data: SignUpSchemaType) => {
         },
       };
     }
+    */
 
     return { success: true, error: null };
   } catch (error) {
@@ -152,6 +114,52 @@ export const validateSignUpSchema = async (data: SignUpSchemaType) => {
     return { success: false, error: '알 수 없는 오류가 발생했습니다' };
   }
 };
+
+export const validateField = (
+  name: string,
+  value: string,
+  formData: { password: string; [key: string]: string }
+) => {
+  switch (name) {
+    case 'nickname':
+      try {
+        BaseSchema.pick({ nickname: true }).parse({ nickname: value });
+        return { error: undefined };
+      } catch (error) {
+        if (error instanceof z.ZodError) {
+          return { error: error.errors[0]?.message || '닉네임 형식이 올바르지 않습니다' };
+        }
+        return { error: '알 수 없는 오류가 발생했습니다' };
+      }
+    case 'email':
+      try {
+        BaseSchema.pick({ email: true }).parse({ email: value });
+        return { error: undefined };
+      } catch (error) {
+        if (error instanceof z.ZodError) {
+          return { error: error.errors[0]?.message || '이메일 형식이 올바르지 않습니다' };
+        }
+        return { error: '알 수 없는 오류가 발생했습니다' };
+      }
+    case 'password':
+      try {
+        BaseSchema.pick({ password: true }).parse({ password: value });
+        return { error: undefined };
+      } catch (error) {
+        if (error instanceof z.ZodError) {
+          return { error: error.errors[0]?.message || '비밀번호 형식이 올바르지 않습니다' };
+        }
+        return { error: '알 수 없는 오류가 발생했습니다' };
+      }
+    case 'checkPassword':
+      return value === formData.password
+        ? { error: undefined }
+        : { error: '비밀번호가 일치하지 않습니다' };
+    default:
+      return { error: undefined };
+  }
+};
+
 
 export const validateLoginSchema = async (data: SignUpSchemaType) => {
   return validateSignUpSchema(data);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,22 +1,36 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite';
 import svgr from 'vite-plugin-svgr';
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [
-    react(),
-    TanStackRouterVite(),
-    svgr({
-      // A minimatch pattern, or array of patterns, which specifies the files in the build the plugin should include.
-      include: '**/*.svg?react',
-    }),
-  ],
-  resolve: {
-    alias: [
-      { find: '@', replacement: '/src' },
-      { find: 'node_modules', replacement: '/node_modules' },
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd());
+  const apiUrl = env.VITE_API_URL;
+  
+  return {
+    plugins: [
+      react(),
+      TanStackRouterVite(),
+      svgr({
+        // A minimatch pattern, or array of patterns, which specifies the files in the build the plugin should include.
+        include: '**/*.svg?react',
+      }),
     ],
-  },
+    resolve: {
+      alias: [
+        { find: '@', replacement: '/src' },
+        { find: 'node_modules', replacement: '/node_modules' },
+      ],
+    },
+    server: {
+      proxy: {
+        '/api': {
+          target: apiUrl,
+          changeOrigin: true,
+          secure: false,
+        }
+      }
+    }
+  };
 });


### PR DESCRIPTION
## ➕ 이슈 링크

- 이슈 넘버 [#22]

## 🔎 작업 내용

- [x] 이메일 코드 전송 api
- [x] 이메일 코드 확인 api
- [x] 사용자 정보 넘기는 api

## 💾 이미지 첨부

![image](https://github.com/user-attachments/assets/77c0fe85-4248-4551-8781-aa088bcfe1fd)
<img width="417" alt="image" src="https://github.com/user-attachments/assets/f9ad8a88-c091-4ab9-8efe-9eb950b96f82" />

## 🔧 리뷰 요구사항

api 작업을 하면서 값 확인을 위해 콘솔을 많이 출력했는데
이 과정에서 lint 규칙에 걸렸으나 우선 푸시했습니다
현재까지 진행한 최종단계의 마무리 기능까지 pr이 완료된 이후에 수정하겠습니다
기능에는 오류 없습니다