### PR TITLE
feat: sns 회원 약관 동의 페이지 구현 (#29)

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as SideBarLayoutVideoArchiveIndexImport } from './routes/_sideBar
 import { Route as SideBarLayoutMyProjectIndexImport } from './routes/_sideBarLayout/my-project/index'
 import { Route as SideBarLayoutMyPageIndexImport } from './routes/_sideBarLayout/my-page/index'
 import { Route as SideBarLayoutDashboardIndexImport } from './routes/_sideBarLayout/dashboard/index'
+import { Route as AuthSignUpSnsIndexImport } from './routes/auth/sign-up/sns/index'
 import { Route as AuthSignUpFinishIndexImport } from './routes/auth/sign-up/finish/index'
 import { Route as AuthCallbackKakaoIndexImport } from './routes/auth/callback/kakao/index'
 import { Route as AuthCallbackGoogleIndexImport } from './routes/auth/callback/google/index'
@@ -88,6 +89,12 @@ const SideBarLayoutDashboardIndexRoute =
     path: '/dashboard/',
     getParentRoute: () => SideBarLayoutRoute,
   } as any)
+
+const AuthSignUpSnsIndexRoute = AuthSignUpSnsIndexImport.update({
+  id: '/auth/sign-up/sns/',
+  path: '/auth/sign-up/sns/',
+  getParentRoute: () => rootRoute,
+} as any)
 
 const AuthSignUpFinishIndexRoute = AuthSignUpFinishIndexImport.update({
   id: '/auth/sign-up/finish/',
@@ -307,6 +314,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthSignUpFinishIndexImport
       parentRoute: typeof rootRoute
     }
+    '/auth/sign-up/sns/': {
+      id: '/auth/sign-up/sns/'
+      path: '/auth/sign-up/sns'
+      fullPath: '/auth/sign-up/sns'
+      preLoaderRoute: typeof AuthSignUpSnsIndexImport
+      parentRoute: typeof rootRoute
+    }
   }
 }
 
@@ -383,6 +397,7 @@ export interface FileRoutesByFullPath {
   '/auth/callback/google': typeof AuthCallbackGoogleIndexRoute
   '/auth/callback/kakao': typeof AuthCallbackKakaoIndexRoute
   '/auth/sign-up/finish': typeof AuthSignUpFinishIndexRoute
+  '/auth/sign-up/sns': typeof AuthSignUpSnsIndexRoute
 }
 
 export interface FileRoutesByTo {
@@ -405,6 +420,7 @@ export interface FileRoutesByTo {
   '/auth/callback/google': typeof AuthCallbackGoogleIndexRoute
   '/auth/callback/kakao': typeof AuthCallbackKakaoIndexRoute
   '/auth/sign-up/finish': typeof AuthSignUpFinishIndexRoute
+  '/auth/sign-up/sns': typeof AuthSignUpSnsIndexRoute
 }
 
 export interface FileRoutesById {
@@ -429,6 +445,7 @@ export interface FileRoutesById {
   '/auth/callback/google/': typeof AuthCallbackGoogleIndexRoute
   '/auth/callback/kakao/': typeof AuthCallbackKakaoIndexRoute
   '/auth/sign-up/finish/': typeof AuthSignUpFinishIndexRoute
+  '/auth/sign-up/sns/': typeof AuthSignUpSnsIndexRoute
 }
 
 export interface FileRouteTypes {
@@ -453,6 +470,7 @@ export interface FileRouteTypes {
     | '/auth/callback/google'
     | '/auth/callback/kakao'
     | '/auth/sign-up/finish'
+    | '/auth/sign-up/sns'
   fileRoutesByTo: FileRoutesByTo
   to:
     | ''
@@ -474,6 +492,7 @@ export interface FileRouteTypes {
     | '/auth/callback/google'
     | '/auth/callback/kakao'
     | '/auth/sign-up/finish'
+    | '/auth/sign-up/sns'
   id:
     | '__root__'
     | '/_projectSideBarLayout'
@@ -496,6 +515,7 @@ export interface FileRouteTypes {
     | '/auth/callback/google/'
     | '/auth/callback/kakao/'
     | '/auth/sign-up/finish/'
+    | '/auth/sign-up/sns/'
   fileRoutesById: FileRoutesById
 }
 
@@ -508,6 +528,7 @@ export interface RootRouteChildren {
   AuthCallbackGoogleIndexRoute: typeof AuthCallbackGoogleIndexRoute
   AuthCallbackKakaoIndexRoute: typeof AuthCallbackKakaoIndexRoute
   AuthSignUpFinishIndexRoute: typeof AuthSignUpFinishIndexRoute
+  AuthSignUpSnsIndexRoute: typeof AuthSignUpSnsIndexRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
@@ -519,6 +540,7 @@ const rootRouteChildren: RootRouteChildren = {
   AuthCallbackGoogleIndexRoute: AuthCallbackGoogleIndexRoute,
   AuthCallbackKakaoIndexRoute: AuthCallbackKakaoIndexRoute,
   AuthSignUpFinishIndexRoute: AuthSignUpFinishIndexRoute,
+  AuthSignUpSnsIndexRoute: AuthSignUpSnsIndexRoute,
 }
 
 export const routeTree = rootRoute
@@ -538,7 +560,8 @@ export const routeTree = rootRoute
         "/help/password/",
         "/auth/callback/google/",
         "/auth/callback/kakao/",
-        "/auth/sign-up/finish/"
+        "/auth/sign-up/finish/",
+        "/auth/sign-up/sns/"
       ]
     },
     "/_projectSideBarLayout": {
@@ -628,6 +651,9 @@ export const routeTree = rootRoute
     },
     "/auth/sign-up/finish/": {
       "filePath": "auth/sign-up/finish/index.tsx"
+    },
+    "/auth/sign-up/sns/": {
+      "filePath": "auth/sign-up/sns/index.tsx"
     }
   }
 }

--- a/src/routes/auth/callback/google/index.tsx
+++ b/src/routes/auth/callback/google/index.tsx
@@ -31,7 +31,7 @@ function RouteComponent() {
         localStorage.setItem('userProfile', JSON.stringify(response.data.user));
         localStorage.setItem('token', response.data.token);
 
-        navigate({ to: '/auth/sign-in' });
+        navigate({ to: '/auth/sign-up/sns' });
       } catch {
         setError('로그인 처리 중 오류가 발생했습니다.');
         setLoading(false);

--- a/src/routes/auth/callback/kakao/index.tsx
+++ b/src/routes/auth/callback/kakao/index.tsx
@@ -34,7 +34,7 @@ function RouteComponent() {
         localStorage.setItem('userProfile', JSON.stringify(response.data.user));
         localStorage.setItem('token', response.data.token);
 
-        navigate({ to: '/auth/sign-in' });
+        navigate({ to: '/auth/sign-up/sns' });
       } catch {
         setError('로그인 처리 중 오류가 발생했습니다.');
         setLoading(false);

--- a/src/routes/auth/sign-up/sns/index.tsx
+++ b/src/routes/auth/sign-up/sns/index.tsx
@@ -1,0 +1,169 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { useState } from 'react';
+import check from '@/assets/auth/check-active.svg';
+import AgreeComponent from '@/components/auth/sign-in/agreement';
+import { VscTriangleLeft } from 'node_modules/react-icons/vsc';
+import { Link, useNavigate } from '@tanstack/react-router';
+import styled from 'styled-components';
+import theme from '@/styles/theme';
+
+export const Route = createFileRoute('/auth/sign-up/sns/')({
+  component: RouteComponent,
+});
+
+type StyledProps = {
+  $inGroup?: boolean;
+  $isActive?: boolean;
+  disabled?: boolean;
+  $isChecked?: boolean;
+};
+
+function RouteComponent() {
+  const navigate = useNavigate();
+  // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+  const [isChecked, setIsChecked] = useState(false);
+  const [agreements, setAgreements] = useState({
+    privacy: false,
+    terms: false,
+    marketing: false,
+    youtube: false,
+  });
+  const [requiredAgreementsChecked, setRequiredAgreementsChecked] =
+    useState(false);
+
+  function handleAgreementsChange(newAgreements: {
+    privacy: boolean;
+    terms: boolean;
+    marketing: boolean;
+    youtube: boolean;
+  }) {
+    setAgreements(newAgreements);
+  }
+
+  const handleRequiredAgreementChange = (isValid: boolean) => {
+    setRequiredAgreementsChecked(isValid);
+  };
+
+  const handleCompletion = () => {
+    if (requiredAgreementsChecked) {
+      navigate({ to: '/auth/login' });
+    }
+  };
+
+  return (
+    <S.SignInWrapper>
+      <S.SignInContainer>
+        <S.SignInState>
+          <img
+            src={check}
+            alt="check-icon"
+          />
+        </S.SignInState>
+
+        <S.AgreementContainer>
+          <AgreeComponent
+            setIsChecked={setIsChecked}
+            onRequiredAgreementChange={handleRequiredAgreementChange}
+            savedAgreements={agreements}
+            onAgreementsChange={handleAgreementsChange}
+          />
+          <S.FooterContainer>
+            <S.NextButtonContainer
+              $inGroup={false}
+              disabled={!requiredAgreementsChecked}
+              $isActive={requiredAgreementsChecked}
+              onClick={handleCompletion}>
+              <p>완료</p>
+            </S.NextButtonContainer>
+            <S.BackToLogin>
+              <VscTriangleLeft />
+              <Link to="/auth/login">
+                <span>로그인 화면으로</span>
+              </Link>
+            </S.BackToLogin>
+          </S.FooterContainer>
+        </S.AgreementContainer>
+      </S.SignInContainer>
+    </S.SignInWrapper>
+  );
+}
+
+const S = {
+  SignInWrapper: styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 100vh;
+    background-color: ${theme.colors.background};
+  `,
+  SignInContainer: styled.div`
+    width: 30%;
+    height: 90vh;
+    background-color: ${theme.colors.white};
+    display: flex;
+    flex-direction: column;
+
+    h2 {
+      font-size: ${theme.fontSizes.fz32};
+      font-weight: ${theme.fontWeights.bold};
+      text-align: center;
+      color: ${theme.colors.primary};
+      margin-bottom: 4vh;
+    }
+  `,
+  SignInState: styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: row;
+    margin-bottom: 2vh;
+    padding-top: 4vh;
+  `,
+  AgreementContainer: styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    flex: 1;
+    position: relative;
+  `,
+  FooterContainer: styled.div`
+    position: absolute;
+    bottom: 4vh;
+    width: 85%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4vh;
+    padding: 0 2vw;
+    background-color: ${theme.colors.white};
+  `,
+  NextButtonContainer: styled.div<StyledProps>`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 6vh;
+    border-radius: ${theme.radius.medium};
+    background-color: ${(props) =>
+      props.$isActive ? theme.colors.primary : '#ccc'};
+    cursor: ${(props) => (props.disabled ? 'not-allowed' : 'pointer')};
+    opacity: ${(props) => (props.$isActive ? 1 : 0.7)};
+
+    p {
+      font-size: ${theme.fontSizes.fz24};
+      color: ${theme.colors.white};
+    }
+  `,
+  BackToLogin: styled.div`
+    display: flex;
+    align-items: center;
+    font-size: ${theme.fontSizes.fz16};
+    cursor: pointer;
+
+    span {
+      margin-left: 0.26vw;
+    }
+  `,
+};


### PR DESCRIPTION
## ➕ 이슈 링크

- 이슈 넘버 [#29]

## 🔎 작업 내용

- sns 회원가입 전용 약관 동의 페이지 구현

## 💾 이미지 첨부

![image](https://github.com/user-attachments/assets/3e45e0ef-a568-4bb1-890b-dea1d237fe91)


## 🔧 리뷰 요구사항

sns는 토큰을 통해 사용자의 이름 등의 값을 얻어오기 때문에 약관 동의 다음 회원가입의 절차들이 필요하지 않다고 판단하였습니다
따라서 약관 동의만 처리하는 페이지를 구현했습니다
기능은 동일합니다
