### PR TITLE
feat: sns 회원가입 및 로그인 기능 구현 (#48)

### DIFF
--- a/src/api/login/oAuth-config.ts
+++ b/src/api/login/oAuth-config.ts
@@ -5,7 +5,7 @@ export const kakaoOAuth: OAuthProvider = {
   authUrl: 'https://kauth.kakao.com/oauth/authorize',
   tokenUrl: 'https://kauth.kakao.com/oauth/token',
   clientId: import.meta.env.VITE_KAKAO_REST_API, // REST API 키
-  redirectUri: import.meta.env.VITE_API_URL + '/auth/callback/kakao',
+  redirectUri: import.meta.env.VITE_CALLBACK_URL + '/auth/callback/kakao',
   scope: 'profile_nickname profile_image account_email',
 };
 
@@ -15,7 +15,7 @@ export const googleOAuth: OAuthProvider = {
   tokenUrl: 'https://oauth2.googleapis.com/token',
   clientId: import.meta.env.VITE_GOOGLE_CLIENT_ID,
   clientSecret: import.meta.env.VITE_GOOGLE_CLIENT_SECRET,
-  redirectUri: import.meta.env.VITE_API_URL + '/auth/callback/google',
+  redirectUri: import.meta.env.VITE_CALLBACK_URL + '/auth/callback/google',
   scope: 'email profile',
 };
 
@@ -25,7 +25,7 @@ export const youtubeOAuth: OAuthProvider = {
   tokenUrl: 'https://oauth2.googleapis.com/token',
   clientId: import.meta.env.VITE_YOUTUBE_CLIENT_ID,
   clientSecret: import.meta.env.VITE_CLIENT_SECRET,
-  redirectUri: import.meta.env.VITE_OAUTH_CALLBACK_URL + '/youtube',
+  redirectUri: import.meta.env.VITE_CALLBACK_URL + '/youtube',
   scope:
     'https://www.googleapis.com/auth/youtube.readonly https://www.googleapis.com/auth/youtube.upload',
 };

--- a/src/routes/auth/callback/google/index.tsx
+++ b/src/routes/auth/callback/google/index.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, useLocation } from '@tanstack/react-router';
 import { useState, useEffect } from 'react';
 import axios from 'axios';
 import { useNavigate } from '@tanstack/react-router';
+import { setTokens } from '@/utils/Tokens';
 
 export const Route = createFileRoute('/auth/callback/google/')({
   component: RouteComponent,
@@ -26,13 +27,16 @@ function RouteComponent() {
           return;
         }
 
-        const response = await axios.post(
-          import.meta.env.VITE_OAUTH_API_URL + '/google',
-          { code }
-        );
+        const response = await axios.post(import.meta.env.VITE_OAUTH_API_URL, {
+          provider: 'google',
+          code: code,
+        });
 
-        localStorage.setItem('userProfile', JSON.stringify(response.data.user));
-        localStorage.setItem('token', response.data.token);
+        if (response.data) {
+          const { accessToken } = response.data;
+          setTokens(accessToken);
+          //console.log(accessToken);
+        }
 
         navigate({ to: '/auth/sign-up/sns' });
       } catch {

--- a/src/routes/auth/callback/kakao/index.tsx
+++ b/src/routes/auth/callback/kakao/index.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react';
-import axios from 'axios';
 import {
   createFileRoute,
   useLocation,
   useNavigate,
 } from '@tanstack/react-router';
+import axios from 'node_modules/axios';
+import { setTokens } from '@/utils/Tokens';
 
 export const Route = createFileRoute('/auth/callback/kakao/')({
   component: RouteComponent,
@@ -29,13 +30,16 @@ function RouteComponent() {
           return;
         }
 
-        const response = await axios.post(
-          import.meta.env.VITE_OAUTH_API_URL + '/kakao',
-          { code }
-        );
+        const response = await axios.post(import.meta.env.VITE_OAUTH_API_URL, {
+          provider: 'kakao',
+          code: code,
+        });
 
-        localStorage.setItem('userProfile', JSON.stringify(response.data.user));
-        localStorage.setItem('token', response.data.token);
+        if (response.data) {
+          const { accessToken } = response.data;
+          setTokens(accessToken);
+          //console.log(accessToken);
+        }
 
         navigate({ to: '/auth/sign-up/sns' });
       } catch {


### PR DESCRIPTION
## ➕ 이슈 링크

- 이슈 넘버 [#48]

## 🔎 작업 내용

카카오와 구글 로그인에서 얻은 code를 백엔드로 보내 사용자 정보를 등록시키고 accessToken을 응답받아
전역상태로 accessToken을 설정하여 사용자 인증을 시킵니다


## 💾 이미지 첨부

### 카카오
![image](https://github.com/user-attachments/assets/b28948fe-a36f-4acc-915b-117dff430ac8)
![image](https://github.com/user-attachments/assets/430e48fa-44ed-4878-92b6-9bb36d09972a)

### 구글
![image](https://github.com/user-attachments/assets/3df82c0c-0beb-4cf9-bba6-c199a047e945)
![image](https://github.com/user-attachments/assets/bb110b06-83cf-451d-8bfe-c30fc9318171)

## 🔧 리뷰 요구사항

우선 코드를 받아 백엔드에 보내 사용자 회원 가입을 완료하고, 
다시 클릭시 카카오톡/구글 로그인 기능을 수행하도록 합니다

백엔드분들께서 작업 완료하시면 accessToken.값 확인해봐서 기능 마무리 짓겠습니다