### PR TITLE
feat: 기사 입력 페이지 api작업 (#57)

### DIFF
--- a/src/api/project/api.ts
+++ b/src/api/project/api.ts
@@ -10,3 +10,43 @@ export const fetchProjects = async (projectId: string) => {
     throw error;
   }
 };
+
+export const postProjectTitle = async (projectId: string, title: string) => {
+  try {
+    const response = await api.post(
+      `/api/v1/projects/${projectId}/updateTitle`,
+      {
+        name: title,
+      }
+    );
+
+    return response.data;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('프로젝트 제목 업데이트 실패:', error);
+    throw error;
+  }
+};
+
+export const suggestArticle = async (article: string) => {
+  try {
+    const response = await api.post('/api/v1/templates/suggest', { article });
+    return response.data;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error suggesting article:', error);
+    throw error;
+  }
+};
+export const updateArticle = async (projectId: string, article: string) => {
+  try {
+    const response = await api.post(`/api/v1/article/${projectId}/update`, {
+      article,
+    });
+    return response.data;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error updating article:', error);
+    throw error;
+  }
+};

--- a/src/components/project-editor/header/index.tsx
+++ b/src/components/project-editor/header/index.tsx
@@ -3,24 +3,48 @@ import React, { useEffect, useRef, useState } from 'react';
 import theme from '@/styles/theme';
 import BackIcon from '@/assets/projectIcon/back.svg?react';
 import EditIcon from '@/assets/projectIcon/edit-2.svg?react';
-import { Link, useLocation } from '@tanstack/react-router';
+import { Link, useLocation, useRouter } from '@tanstack/react-router';
 import useArticlePDFStore from '@/store/useArticlePDFStore';
 import { pdfjs } from 'react-pdf';
 import { TextItem } from 'pdfjs-dist/types/src/display/api';
 import Modal from '@/components/common/modal';
 import EditModal from '../modal/editModal';
 import { Route } from '@/routes/__root';
-import { fetchProjects } from '@/api/project/api';
+import {
+  fetchProjects,
+  postProjectTitle,
+  suggestArticle,
+} from '@/api/project/api';
+import useProjectEditorStore from '@/store/useProjectEditorStore';
 
 pdfjs.GlobalWorkerOptions.workerSrc = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.mjs`;
 
-const ProjectHeader = () => {
-  const { project } = Route.useParams();
+interface MediaAndAvatarData {
+  items: {
+    data: {
+      background?: {
+        type?: string;
+        fileUrl?: string;
+      };
+      avatar?: {
+        fileUrl?: string;
+      };
+    };
+  }[];
+}
 
-  const [projects, setProjects] = useState([]);
+const ProjectHeader = () => {
+  const location = useLocation();
+  const { project } = Route.useParams();
+  const router = useRouter();
+  const { projectData, setProjectData } = useProjectEditorStore();
+  const { articlePDFText, setArticlePDFText, clearArticlePDFText } =
+    useArticlePDFStore();
+
+  const [projectTitle, setProjectTitle] = useState(
+    projectData?.name || '새 프로젝트'
+  );
   const [isEdit, setIsEdit] = useState(false);
-  const [projectTitle, setProjectTitle] = useState('새 프로젝트');
-  const { setArticlePDFText, clearArticlePDFText } = useArticlePDFStore();
   const inputRef = useRef<HTMLInputElement>(null);
   const handleInput = () => {
     if (inputRef.current) {
@@ -32,18 +56,46 @@ const ProjectHeader = () => {
     const loadProjects = async () => {
       try {
         const data = await fetchProjects(project);
-        setProjects(data);
+        setProjectData(data);
       } catch (err) {
         alert(err);
       }
     };
     loadProjects();
-  }, [project]);
-  // eslint-disable-next-line no-console
-  console.log(projects);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (projectData?.name) {
+      setProjectTitle(projectData.name);
+    }
+  }, [projectData?.name]);
 
   const onChangeProjectTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
     setProjectTitle(e.target.value);
+  };
+
+  const handleSaveProjectTitle = async () => {
+    if (isEdit) {
+      try {
+        if (projectData?.name) {
+          await postProjectTitle(project, projectData.name);
+          setProjectData({
+            id: projectData.id || '',
+            name: projectTitle,
+            scenes: projectData.scenes || [],
+          });
+          setIsEdit(false);
+        }
+      } catch (err) {
+        alert('제목 저장에 실패했습니다.');
+        // eslint-disable-next-line no-console
+        console.log(err);
+        setProjectTitle(projectData?.name || '새 프로젝트');
+      }
+    } else {
+      setIsEdit(true);
+    }
   };
 
   const handleFileUpload = async (
@@ -95,7 +147,42 @@ const ProjectHeader = () => {
       }
     };
   };
-  const location = useLocation();
+
+  const updateMediaAndAvatar = (data: MediaAndAvatarData) => {
+    useProjectEditorStore.setState((state) => {
+      if (!state.projectData) return state;
+
+      return {
+        projectData: {
+          ...state.projectData,
+          scenes: state.projectData.scenes.map((scene, index) => ({
+            ...scene,
+            media: {
+              type: data.items[index]?.data.background?.type || 'image',
+              url: data.items[index]?.data.background?.fileUrl || '',
+              position: { x: 0, y: 0 },
+            },
+            avatar: {
+              type: 'image',
+              url: data.items[index]?.data.avatar?.fileUrl || '',
+              position: { x: 0, y: 0 },
+            },
+          })),
+        },
+      };
+    });
+  };
+
+  const submitArticle = async (article: string) => {
+    try {
+      const templateData = await suggestArticle(article);
+      updateMediaAndAvatar(templateData);
+
+      router.navigate({ to: '/$project/template', params: { project } });
+    } catch (error) {
+      alert(error);
+    }
+  };
   return (
     <>
       <S.HeaderContainer>
@@ -114,10 +201,7 @@ const ProjectHeader = () => {
                 {projectTitle}
               </S.ViewText>
             )}
-            <EditIcon
-              color="black"
-              onClick={() => setIsEdit(!isEdit)}
-            />
+            <EditIcon onClick={handleSaveProjectTitle} />
           </S.TitleBox>
         </S.HeaderLeftContents>
         <S.ButtonBox>
@@ -132,9 +216,11 @@ const ProjectHeader = () => {
                   ref={inputRef}
                 />
               </S.ArticleUploadButton>
-              <S.HeaderButton>템플릿 추천</S.HeaderButton>
+              <S.HeaderButton onClick={() => submitArticle(articlePDFText)}>
+                템플릿 추천
+              </S.HeaderButton>
               <Link
-                to="/$project/avatar"
+                to="/$project/background"
                 params={{ project: '1' }}>
                 <S.HeaderButton>템플릿 없이 진행하기</S.HeaderButton>
               </Link>

--- a/src/mock/handlers.ts
+++ b/src/mock/handlers.ts
@@ -1,16 +1,16 @@
 import { http, HttpResponse } from 'msw';
-import dummyData from './dummy.json';
-
+import projectDummy from './projectDummy.json';
+import suggestArticleDummyData from './suggestArticleDummyData.json';
 export const handlers = [
   http.get(
     `${import.meta.env.VITE_API_URL}/api/v1/projects/:id`,
     async ({ params }) => {
       const { id } = params;
 
-      const project = dummyData.projects.find((p) => p.id === Number(id));
+      const project = projectDummy;
 
       //임의로 오류 코드 404 반환하도록 설정했음
-      if (!project) {
+      if (project.id !== id) {
         return HttpResponse.json(
           { message: 'Project not found' },
           { status: 404 }
@@ -18,6 +18,61 @@ export const handlers = [
       }
 
       return HttpResponse.json(project, { status: 200 });
+    }
+  ),
+
+  http.post(
+    `${import.meta.env.VITE_API_URL}/api/v1/projects/:id/updateTitle`,
+    async ({ params, request }) => {
+      const { id } = params;
+      const { name } = (await request.json()) as { name: string };
+      if (!name) {
+        return HttpResponse.json(
+          { message: 'article not found' },
+          { status: 404 }
+        );
+      }
+      return HttpResponse.json(
+        {
+          success: true,
+          message: `프로젝트 ${id}의 제목이 성공적으로 업데이트되었습니다.`,
+          updatedName: name,
+        },
+        { status: 200 }
+      );
+    }
+  ),
+  http.post(
+    `${import.meta.env.VITE_API_URL}/api/v1/templates/suggest`,
+    async (article) => {
+      if (!article) {
+        return HttpResponse.json(
+          { message: 'article not found' },
+          { status: 404 }
+        );
+      }
+      return HttpResponse.json(suggestArticleDummyData, { status: 200 });
+    }
+  ),
+  http.post(
+    `${import.meta.env.VITE_API_URL}/api/v1/article/:id/update`,
+    async ({ params, request }) => {
+      const { id } = params;
+      const { article } = (await request.json()) as { article: string };
+      if (!article) {
+        return HttpResponse.json(
+          { message: 'article not found' },
+          { status: 404 }
+        );
+      }
+      return HttpResponse.json(
+        {
+          success: true,
+          message: `프로젝트 ${id}의 기사가가 성공적으로 업데이트되었습니다.`,
+          updatedArticle: name,
+        },
+        { status: 200 }
+      );
     }
   ),
 ];

--- a/src/mock/projectDummy.json
+++ b/src/mock/projectDummy.json
@@ -1,0 +1,63 @@
+{
+  "_schema_version": "1.0",
+  "id": "1",
+  "name": "테스트 프로젝트",
+  "scenes": [
+    {
+      "id": "<scene-id-1>",
+      "transcript": [
+        {
+          "id": "<transcript-id-1>",
+          "text": "설 연휴를 지나며 자영업자들이 겪고있는 위기.",
+          "postDelay": 300
+        },
+        {
+          "id": "<transcript-id-2>",
+          "text": "설 연휴, 자영업자들은 역대급 '냉동고 한파'와 폭설에 시달렸습니다.",
+          "postDelay": 300
+        }
+      ],
+      "subtitle": {
+        "text": "설 연휴 한파로 인한 자영업자 영업 위기",
+        "fontFamily": "NanumGothic",
+        "fontSize": 24,
+        "fontColor": "#ffffff",
+        "backgroundColor": "#000000",
+        "position": {
+          "x": 0,
+          "y": 0
+        },
+        "bold": true
+      },
+      "media": {
+        "type": "image",
+        "width": 1920,
+        "height": 1080,
+        "url": "https://example.com/image1.jpg",
+        "position": {
+          "x": 0,
+          "y": 0
+        },
+        "scale": 1.0,
+        "viewport": [0, 0, 1920, 1080]
+      },
+      "avatar": {
+        "type": "image",
+        "width": 1920,
+        "height": 1080,
+        "url": "https://example.com/image1.jpg",
+        "position": {
+          "x": 0,
+          "y": 0
+        },
+        "scale": 1.0,
+        "viewport": [0, 0, 1920, 1080]
+      }
+    }
+  ],
+  "props": {
+    "width": 1920,
+    "height": 1080,
+    "background": "#000000"
+  }
+}

--- a/src/mock/suggestArticleDummyData.json
+++ b/src/mock/suggestArticleDummyData.json
@@ -1,0 +1,45 @@
+{
+  "items": [
+    {
+      "id": 9007199254740991,
+      "priority": 1073741824,
+      "data": {
+        "name": "string",
+        "category": "Social",
+        "size": {
+          "width": 1073741824,
+          "height": 1073741824
+        },
+        "background": {
+          "id": 9007199254740991,
+          "name": "string",
+          "priority": 1073741824,
+          "type": "Image",
+          "fileUrl": "string",
+          "size": {
+            "width": 1073741824,
+            "height": 1073741824
+          },
+          "createdAt": "2025-03-25T12:24:11.464Z",
+          "updatedAt": "2025-03-25T12:24:11.464Z"
+        },
+        "avatar": {
+          "id": 9007199254740991,
+          "name": "string",
+          "priority": 1073741824,
+          "fileUrl": "string",
+          "createdAt": "2025-03-25T12:24:11.464Z",
+          "updatedAt": "2025-03-25T12:24:11.464Z"
+        }
+      },
+      "createdAt": "2025-03-25T12:24:11.464Z",
+      "updatedAt": "2025-03-25T12:24:11.464Z"
+    }
+  ],
+  "_info": {
+    "category": {
+      "id": 1073741824,
+      "name": "string"
+    }
+  }
+}

--- a/src/routes/_projectSideBarLayout/$project/article/index.tsx
+++ b/src/routes/_projectSideBarLayout/$project/article/index.tsx
@@ -1,3 +1,4 @@
+import { updateArticle } from '@/api/project/api';
 import { useDebounce } from '@/hook/useDebounce';
 import useArticlePDFStore from '@/store/useArticlePDFStore';
 import theme from '@/styles/theme';
@@ -13,20 +14,21 @@ export const Route = createFileRoute(
 
 function RouteComponent() {
   const [article, setArticle] = useState('');
-  const { articlePDFText } = useArticlePDFStore();
+  const { articlePDFText, setArticlePDFText } = useArticlePDFStore();
+  const { project } = Route.useParams();
 
   const debouncedArticle = useDebounce(article, 1000);
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setArticlePDFText(e.target.value);
     setArticle(e.target.value);
   };
 
   useEffect(() => {
     if (debouncedArticle) {
-      // console.log(debouncedArticle);
-      //추후 저장 로직으로 변경 예정
+      updateArticle(project, article);
     }
-  }, [debouncedArticle]);
+  }, [debouncedArticle, article, project]);
 
   useEffect(() => {
     if (articlePDFText != '') {

--- a/src/store/useProjectEditorStore.ts
+++ b/src/store/useProjectEditorStore.ts
@@ -1,0 +1,50 @@
+import { create } from 'zustand';
+
+interface Scene {
+  id: string;
+  transcript: { id: string; text: string; postDelay: string }[];
+  subtitle: {
+    text: string;
+    fontFamily: string;
+    fontSize: number;
+    fontColor: string;
+    backgroundColor: string;
+  };
+  media: {
+    type: string;
+    url: string;
+    position: {
+      x: number;
+      y: number;
+    };
+  };
+  avatar: {
+    type: string;
+    url: string;
+    position: {
+      x: number;
+      y: number;
+    };
+  };
+}
+
+interface Project {
+  id: string;
+  name: string;
+  scenes: Scene[];
+}
+
+interface ProjectState {
+  projectData: Project | null;
+  // eslint-disable-next-line no-unused-vars
+  setProjectData: (project: Project) => void;
+  resetProjectData: () => void;
+}
+
+const useProjectEditorStore = create<ProjectState>((set) => ({
+  projectData: null,
+  setProjectData: (projectData) => set({ projectData }),
+  resetProjectData: () => set({ projectData: null }),
+}));
+
+export default useProjectEditorStore;


### PR DESCRIPTION
## ➕ 이슈 링크

- #57 

## 🔎 작업 내용

- 프로젝트 에디터 헤더에 위치한 프로젝트 이름, 템플릿 추천 버튼에 관련 api 작업 진행(프로젝트 이름 수정 후 아이콘 클릭 시 프로젝트 이름 업로드 api 호출, 템플릿 추천 버튼 클릭 시 입력 된 기사 기반 템플릿 추천 api 호출 및 전송 완료 시 템플릿 선택 페이지로 이동)

- 기사 입력 페이지 useDebounce 적용

- 관련 api는 msw로 임의로 api 테스트를 했으며, api 수정 및 추후 배포 환경에서 테스트가 필요합니다.

## 🔧 리뷰 요구사항

- 가독성이 떨어질 순 있지만... 혹시나 문제가 있는거 같은 로직이 있다면 적극적인 피드백 환영합니당
