### PR TITLE
feat: 대시보드와 내 프로젝트, 영상보관함 api 연동 (#73)

### DIFF
--- a/src/api/dashboard/api.ts
+++ b/src/api/dashboard/api.ts
@@ -37,3 +37,30 @@ export const postProject = async () => {
     console.error(error);
   }
 };
+
+export const deleteProject = async (projectId: number) => {
+  const { accessToken } = getTokens();
+
+  try {
+    const response = await api.delete(`/api/projects/${projectId}`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    // 204 No Content는 성공적인 삭제를 의미
+    if (response.status === 204) {
+      return {
+        success: true,
+        message: '프로젝트가 성공적으로 삭제되었습니다.',
+      };
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.log(error);
+    return {
+      success: false,
+      message: '알 수 없는 오류가 발생했습니다.',
+    };
+  }
+};

--- a/src/api/video-archive/api.ts
+++ b/src/api/video-archive/api.ts
@@ -1,0 +1,28 @@
+import api from '@/api/login/api';
+import { getTokens } from '@/utils/Tokens';
+
+export type videoArchiveType = {
+  id: number;
+  projectId: number;
+  jobId: string;
+  type: string;
+  status: string;
+  retryCount: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export const getVideoArchive = async () => {
+  const { accessToken } = getTokens();
+  try {
+    const response = await api.get('/api/v1/tasks', {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    return response.data;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error);
+  }
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,28 +9,13 @@ declare module '@tanstack/react-router' {
     router: typeof router;
   }
 }
-async function enableMocking() {
-  if (import.meta.env.MODE !== 'development') {
-    return;
-  }
-
-  const { worker } = await import('./mock/browser'); // Dynamic Import
-  return worker.start();
+// Render the app
+const rootElement = document.getElementById('root')!;
+if (!rootElement.innerHTML) {
+  const root = ReactDOM.createRoot(rootElement);
+  root.render(
+    <StrictMode>
+      <App />
+    </StrictMode>
+  );
 }
-
-// MSW가 설정된 후에만 렌더링
-enableMocking().then(() => {
-  const rootElement = document.getElementById('root');
-  if (!rootElement) {
-    throw new Error('Root element not found');
-  }
-
-  if (!rootElement.innerHTML) {
-    const root = ReactDOM.createRoot(rootElement);
-    root.render(
-      <StrictMode>
-        <App />
-      </StrictMode>
-    );
-  }
-});

--- a/src/routes/_sideBarLayout/dashboard/_components/myProjectCard.tsx
+++ b/src/routes/_sideBarLayout/dashboard/_components/myProjectCard.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, Link } from '@tanstack/react-router';
 import FileEditIcon from '@/assets/icons/icon-file-edit.svg?react';
 import styled from 'styled-components';
 import Loading from '@/components/common/spinner';
@@ -20,6 +20,7 @@ interface ProjectProps {
 }
 
 function MyProjectCard({
+  id,
   name,
   active,
   // version,
@@ -28,36 +29,39 @@ function MyProjectCard({
   updatedAt,
 }: ProjectProps) {
   return (
-    <S.CardWrap>
-      <S.CardImage className="card-image">
-        <img
-          src="https://img.freepik.com/free-vector/staff-creating-film_1262-20681.jpg?t=st=1742560845~exp=1742564445~hmac=c96983f5ebf8d7db96d12092ed3ffe4ffe7eefbfec031d8de5d8eaaa804e80ca&w=1800"
-          alt="test-img"
-        />
-        {active && (
-          <S.CardBackDrop>
-            <S.LoadingIcon>
-              <Loading />
-            </S.LoadingIcon>
-            <S.ProgressState>
-              <p>{`75`}%</p>
-              <S.ProgressBarWrap>
-                <S.ProgressBar></S.ProgressBar>
-              </S.ProgressBarWrap>
-            </S.ProgressState>
-          </S.CardBackDrop>
-        )}
-      </S.CardImage>
-      <S.CardContent>
-        <p>
-          <FileEditIcon />
-        </p>
-        <div>
-          <h4>{name}</h4>
-          <p>{updatedAt}</p>
-        </div>
-      </S.CardContent>
-    </S.CardWrap>
+    <Link to={`/project/${id}/article`}>
+      <S.CardWrap>
+        <S.CardImage className="card-image">
+          {/* 추후 받은 이미지로 변경 해야합니다 */}
+          <img
+            src="https://img.freepik.com/free-vector/staff-creating-film_1262-20681.jpg?t=st=1742560845~exp=1742564445~hmac=c96983f5ebf8d7db96d12092ed3ffe4ffe7eefbfec031d8de5d8eaaa804e80ca&w=1800"
+            alt="test-img"
+          />
+          {active && (
+            <S.CardBackDrop>
+              <S.LoadingIcon>
+                <Loading />
+              </S.LoadingIcon>
+              <S.ProgressState>
+                <p>{`75`}%</p>
+                <S.ProgressBarWrap>
+                  <S.ProgressBar></S.ProgressBar>
+                </S.ProgressBarWrap>
+              </S.ProgressState>
+            </S.CardBackDrop>
+          )}
+        </S.CardImage>
+        <S.CardContent>
+          <p>
+            <FileEditIcon />
+          </p>
+          <div>
+            <h4>{name}</h4>
+            <p>{updatedAt}</p>
+          </div>
+        </S.CardContent>
+      </S.CardWrap>
+    </Link>
   );
 }
 

--- a/src/routes/_sideBarLayout/dashboard/index.tsx
+++ b/src/routes/_sideBarLayout/dashboard/index.tsx
@@ -47,7 +47,7 @@ function RouteComponent() {
     const fetchProjects = async () => {
       try {
         const data = await getProjects();
-        setProjects(data.projects);
+        setProjects(data.data);
       } catch (err) {
         alert(`${err}`);
       }
@@ -118,12 +118,14 @@ function RouteComponent() {
         </h2>
         {projects && projects.length > 0 ? (
           <Slider {...settings}>
-            {projects.map((project) => (
-              <MyProjectCard
-                key={project.id}
-                {...project}
-              />
-            ))}
+            {projects.map((project) => {
+              return (
+                <MyProjectCard
+                  key={project.id}
+                  {...project}
+                />
+              );
+            })}
           </Slider>
         ) : (
           <S.EmptyProjectCard onClick={_handlecreateProject}>

--- a/src/routes/_sideBarLayout/my-project/_components/projectCard.tsx
+++ b/src/routes/_sideBarLayout/my-project/_components/projectCard.tsx
@@ -1,10 +1,11 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, Link } from '@tanstack/react-router';
 import styled from 'styled-components';
 import MoreIcon from '@/assets/icons/icon-more.svg?react';
 import AvatarIcon from '@/assets/icons/icon-default-avatar.svg?react';
 import ScreenRatioIcon from '@/assets/icons/icon-screen-ratio.svg?react';
 import { useState, useRef, useEffect } from 'react';
 import { useDialog } from '@/hook/useDialog';
+import { deleteProject } from '@/api/dashboard/api';
 
 export const Route = createFileRoute(
   '/_sideBarLayout/my-project/_components/projectCard'
@@ -13,28 +14,37 @@ export const Route = createFileRoute(
 });
 
 interface ProjectProps {
-  title: string;
+  // title: string;
+  // updatedAt: string;
+  // isLoaded: boolean;
+  // progress: number;
+  id: number;
+  name: string;
+  active: boolean;
+  version: number;
+  lastAccessedAt: string;
+  createdAt: string;
   updatedAt: string;
-  isLoaded: boolean;
-  progress: number;
 }
 
-function ProjectCard({ title }: ProjectProps) {
+function ProjectCard(project: ProjectProps) {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const { alert, confirm } = useDialog();
   const ref = useRef<HTMLUListElement>(null);
 
   const _handleCopyBtn = () => {
     alert('복사본이 생성되었습니다.');
+
     setIsOpen(false);
   };
-  const _handleDeleteBtn = async () => {
+  const _handleDeleteBtn = async (projectId: number) => {
     const isConfirmed = await confirm(
       '프로젝트를 삭제하시겠습니까?',
       '삭제된 영상은 복구할 수 없습니다.'
     );
     if (isConfirmed) {
-      alert('프로젝트가 삭제되었습니다.');
+      const result = await deleteProject(projectId);
+      if (result) alert(result.message);
     }
 
     setIsOpen(false);
@@ -67,30 +77,35 @@ function ProjectCard({ title }: ProjectProps) {
             <MoreIcon color="#92929D" />
           </p>
         </S.CardTopInfo>
-        <S.ProjectTitle>
-          <h3 className="title">{title}</h3>
-          <div>
-            <p className="description">
-              이것은 대본 요약본입니다. 최대 두줄까지 작성이 가능하고....이것은
-              대본 요약본입니다. 최대 두줄까지 작성이 가능하고....이것은 대본
-              요약본입니다. 최대 두줄까지 작성이 가능하고....이것은 대본
-              요약본입니다. 최대 두줄까지 작성이 가능하고....
+        <Link to={`/project/${project.id}/article`}>
+          <S.ProjectTitle>
+            <h3 className="title">{project.name}</h3>
+            <div>
+              <p className="description">
+                이것은 대본 요약본입니다. 최대 두줄까지 작성이
+                가능하고....이것은 대본 요약본입니다. 최대 두줄까지 작성이
+                가능하고....이것은 대본 요약본입니다. 최대 두줄까지 작성이
+                가능하고....이것은 대본 요약본입니다. 최대 두줄까지 작성이
+                가능하고....
+              </p>
+            </div>
+          </S.ProjectTitle>
+          <S.ProjectInfo>
+            <p className="icon">
+              <ScreenRatioIcon />
             </p>
-          </div>
-        </S.ProjectTitle>
-        <S.ProjectInfo>
-          <p className="icon">
-            <ScreenRatioIcon />
-          </p>
-          <div className="editdate-wrap">
-            <h4 className="editdate">2025-02-27(18분전 수정)</h4>
-          </div>
-        </S.ProjectInfo>
+            <div className="editdate-wrap">
+              <h4 className="editdate">{project.lastAccessedAt}</h4>
+            </div>
+          </S.ProjectInfo>
+        </Link>
       </S.CardWrap>
       {isOpen && (
         <S.ModalMenu ref={ref}>
           <S.ModalItem onClick={_handleCopyBtn}>복제하기</S.ModalItem>
-          <S.ModalItem onClick={_handleDeleteBtn}>삭제하기</S.ModalItem>
+          <S.ModalItem onClick={() => _handleDeleteBtn(project.id)}>
+            삭제하기
+          </S.ModalItem>
         </S.ModalMenu>
       )}
     </div>

--- a/src/routes/_sideBarLayout/my-project/index.tsx
+++ b/src/routes/_sideBarLayout/my-project/index.tsx
@@ -1,10 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import styled from 'styled-components';
 import ProjectCard from './_components/projectCard';
 import DropdownSelect from './_components/dropdownSelect';
-import axios from 'axios';
 import EmptyVideoIcon from '@/assets/icons/icon-empty-video.svg?react';
+import { getProjects } from '@/api/dashboard/api';
+import { sortProjects } from '@/utils/sort';
 
 export const Route = createFileRoute('/_sideBarLayout/my-project/')({
   component: RouteComponent,
@@ -12,19 +13,25 @@ export const Route = createFileRoute('/_sideBarLayout/my-project/')({
 
 type TabKey = 'all' | 'editing' | 'cmpltRendering';
 
-interface IProject {
+export interface IProject {
+  // id: number;
+  // title: string;
+  // updatedAt: string;
+  // isLoaded: boolean;
+  // progress: number;
   id: number;
-  title: string;
+  name: string;
+  active: boolean;
+  version: number;
+  lastAccessedAt: string;
+  createdAt: string;
   updatedAt: string;
-  isLoaded: boolean;
-  progress: number;
 }
 
 function RouteComponent() {
   const [projects, setProjects] = useState<IProject[]>([]);
   const [selectItems, setSelectItems] = useState<string>('생성일자');
   const [activeTab, setActiveTab] = useState<TabKey>('all');
-  const PROJECT_DUMMY = '/src/mock/dummy.json';
 
   const tabMenus = [
     { label: '전체', value: 'all' },
@@ -33,21 +40,34 @@ function RouteComponent() {
   ];
 
   useEffect(() => {
-    const _getProjects = async () => {
+    const fetchProjects = async () => {
       try {
-        const res = await axios.get(PROJECT_DUMMY);
-        setProjects(res.data.projects);
+        const data = await getProjects();
+        setProjects(data.data);
       } catch (err) {
         alert(`${err}`);
       }
     };
 
-    _getProjects();
+    fetchProjects();
   }, []);
+
+  const sortedProjects = useMemo(() => {
+    let filteredProjects = projects;
+
+    // 탭에 따른 필터링 추가
+    if (activeTab === 'editing') {
+      filteredProjects = projects.filter((project) => project.active);
+    } else if (activeTab === 'cmpltRendering') {
+      filteredProjects = projects.filter((project) => !project.active);
+    }
+
+    return sortProjects(filteredProjects, selectItems);
+  }, [projects, selectItems, activeTab]);
 
   return (
     <S.MyProjectWrap>
-      {projects.length > 0 ? (
+      {sortedProjects && sortedProjects.length > 0 ? (
         <>
           <S.TopSortSect>
             <S.DropDownWrap>

--- a/src/routes/_sideBarLayout/video-archive/index.tsx
+++ b/src/routes/_sideBarLayout/video-archive/index.tsx
@@ -7,32 +7,35 @@ import {
   flexRender,
 } from '@tanstack/react-table';
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
 import styled from 'styled-components';
 import DownloadIcon from '@/assets/icons/icon-download.svg?react';
 import CheckIcon from '@/assets/icons/icon-check.svg?react';
 import LeftArrow from '@/assets/icons/icon-table-left-arrow.svg?react';
 import RightArrow from '@/assets/icons/icon-table-right-arrow.svg?react';
+import { getVideoArchive, videoArchiveType } from '@/api/video-archive/api';
 
 export const Route = createFileRoute('/_sideBarLayout/video-archive/')({
   component: RouteComponent,
 });
 
-type TableProps = {
-  id: number;
-  title: string;
-  updatedAt: string;
-  progress: boolean;
-  playTime: number;
-  isPlaying: boolean;
-};
-
 function RouteComponent() {
-  const [data, setData] = useState<TableProps[]>([]);
+  const [data, setData] = useState<videoArchiveType[]>([]);
   const [selectedRows, setSelectedRows] = useState<Record<number, boolean>>({});
   const [pageSize, setPageSize] = useState<number>(10);
   const [pageIndex, setPageIndex] = useState(0);
-  const PROJECT_DUMMY = '/src/mock/dummy.json';
+
+  useEffect(() => {
+    const fetchProjects = async () => {
+      try {
+        const response = await getVideoArchive();
+        setData(response.data);
+      } catch (err) {
+        alert(`${err}`);
+      }
+    };
+
+    fetchProjects();
+  }, []);
 
   const selectAllRow = (isChecked: boolean) => {
     if (isChecked) {
@@ -64,7 +67,7 @@ function RouteComponent() {
   const isAllSelected =
     data.length > 0 && Object.keys(selectedRows).length === data.length;
 
-  const columns: ColumnDef<TableProps>[] = [
+  const columns: ColumnDef<videoArchiveType>[] = [
     {
       accessorKey: 'task',
       header: () => (
@@ -188,18 +191,6 @@ function RouteComponent() {
     setPageIndex(0);
   };
 
-  useEffect(() => {
-    const _getVideoData = async () => {
-      try {
-        const res = await axios.get(PROJECT_DUMMY);
-        setData(res.data.videoHistory);
-      } catch (err) {
-        alert(`${err}`);
-      }
-    };
-
-    _getVideoData();
-  }, []);
   return (
     <S.VideoArchiveWrap>
       <S.VideoTableContent>

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -1,0 +1,26 @@
+import { IProject } from '@/routes/_sideBarLayout/my-project';
+
+export function sortProjects(projects: IProject[], sortBy: string): IProject[] {
+  switch (sortBy) {
+    case '생성일자':
+      return [...projects].sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      );
+    case '이름':
+      return [...projects].sort((a, b) => a.name.localeCompare(b.name));
+    case '최종수정날짜':
+      return [...projects].sort(
+        (a, b) =>
+          new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+      );
+    case '마지막 열어본 시간':
+      return [...projects].sort(
+        (a, b) =>
+          new Date(b.lastAccessedAt).getTime() -
+          new Date(a.lastAccessedAt).getTime()
+      );
+    default:
+      return projects;
+  }
+}


### PR DESCRIPTION
## ➕ 이슈 링크

- 이슈 넘버 #[issue_number]

## 🔎 작업 내용

- [x] 대시보드 
- [x] 내 프로젝트
- [x] 영상 보관함 

## 💾 이미지 첨부

### 대시보드
![image](https://github.com/user-attachments/assets/36514f87-f766-4a76-ab36-772d59b11cb4)
### 내 프로젝트
![image](https://github.com/user-attachments/assets/70c0d24a-84b4-4b87-a8bc-aaed4cc8c1c1)


## 🔧 리뷰 요구사항

1. 대시보드에서 슬라이드 기능 동작 확인
2. 내 프로젝트에서 생성일자, 이름, 최종 수정날짜, 마지막으로 열어본시간에 대한 1차 필터링, 
2-1. 전체, 편집중, 렌더링 완료에 따른 2차 필터링 적용
2-2. 삭제 기능 구현

단, 102개로 데이터가 많으면 불러오는데 시간이 오래 걸려서 tanstackQuery의 일정 수만 미리 불러오고, 나머지를 천천히 불러오려고 했으나 페이지네이션의 기능과 동일하기에 백엔드에서도 데이터 구조 변경이 필요해 보입니다

3. 내 프로젝트
백엔드분들과 소통하며 작업하겠습니다
