### PR TITLE
fix: 프로젝트 에디터 서버 데이터 이미지 불러오는 방식 변경 및 저장 된 이미지 불러오지 못하는 현상 수정

### DIFF
--- a/src/api/project/api.ts
+++ b/src/api/project/api.ts
@@ -1,4 +1,4 @@
-import { FetchTemplateResponse } from '@/types/template';
+import { FetchTemplateResponse, TemplateImage } from '@/types/template';
 import api from '../login/api';
 import { ImageType, Transcript } from '@/types/projectData';
 
@@ -92,13 +92,15 @@ export const fetchTemplate = async () => {
 export const patchProjectBackgroundImage = async (
   projectId: number,
   sceneId: number,
-  backgroundImageData: ImageType | null
+  template: TemplateImage
 ) => {
   if (projectId) {
     const response = await api.patch(
       `/api/v1/projects/${projectId}/scenes/${sceneId}`,
       {
-        background: backgroundImageData,
+        background: {
+          templateId: template.id,
+        },
       }
     );
     return response;

--- a/src/api/project/api.ts
+++ b/src/api/project/api.ts
@@ -1,6 +1,6 @@
 import { FetchTemplateResponse, TemplateImage } from '@/types/template';
 import api from '../login/api';
-import { ImageType, Transcript } from '@/types/projectData';
+import { Transcript } from '@/types/projectData';
 
 export const fetchProjects = async (projectId: string) => {
   try {
@@ -109,13 +109,15 @@ export const patchProjectBackgroundImage = async (
 export const patchProjectAvatarImage = async (
   projectId: number,
   sceneId: number,
-  avatarImageData: ImageType | null
+  template: TemplateImage
 ) => {
   if (projectId) {
     const response = await api.patch(
       `/api/v1/projects/${projectId}/scenes/${sceneId}`,
       {
-        avatar: avatarImageData,
+        avatar: {
+          templateId: template.id,
+        },
       }
     );
     return response;

--- a/src/components/project-editor/dragImage/index.tsx
+++ b/src/components/project-editor/dragImage/index.tsx
@@ -5,6 +5,7 @@ import React, {
   useEffect,
   useCallback,
   useLayoutEffect,
+  useMemo,
 } from 'react';
 import theme from '@/styles/theme';
 import { useDebounce } from '@/hook/useDebounce';
@@ -72,70 +73,66 @@ function DragImage({
     }
   }, [containerRef, isAvatar]);
 
-  useEffect(() => {
-    if (!debouncedPosition || !projectData) return;
-
-    const element = isAvatar
+  const currentElement = useMemo(() => {
+    if (!projectData?.scenes[0]) return null;
+    return isAvatar
       ? projectData.scenes[0].avatar
       : projectData.scenes[0].background;
-    if (!element) return;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectData?.scenes[0], isAvatar]);
+
+  useEffect(() => {
+    if (!currentElement?.position || !projectData) return;
+
+    const newPosition = {
+      x: (currentElement.position.x / referenceDimensions.width) * 100,
+      y: (currentElement.position.y / referenceDimensions.height) * 100,
+    };
+
+    if (
+      Math.abs(position.x - newPosition.x) > 0.1 ||
+      Math.abs(position.y - newPosition.y) > 0.1
+    ) {
+      setPosition(newPosition);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentElement?.position, referenceDimensions, projectData]);
+
+  useEffect(() => {
+    if (!debouncedPosition || !currentElement?.id) return;
 
     const finalX = (debouncedPosition.x / 100) * referenceDimensions.width;
     const finalY = (debouncedPosition.y / 100) * referenceDimensions.height;
 
     if (
-      Math.abs(element.position.x - finalX) < 1 &&
-      Math.abs(element.position.y - finalY) < 1
+      Math.abs(currentElement.position.x - finalX) > 1 ||
+      Math.abs(currentElement.position.y - finalY) > 1
     ) {
-      return;
-    }
-
-    updateElementPosition(isAvatar ?? false, { x: finalX, y: finalY });
-  }, [
-    debouncedPosition,
-    isAvatar,
-    projectData,
-    updateElementPosition,
-    referenceDimensions,
-  ]);
-
-  useEffect(() => {
-    if (debouncedDimensions && containerRef.current) {
-      const finalSize = {
-        width: percentToPxForFinal(
-          debouncedDimensions.width,
-          referenceDimensions.width
-        ),
-        height: percentToPxForFinal(
-          debouncedDimensions.height,
-          referenceDimensions.height
-        ),
-      };
-      updateElementSize(isAvatar ?? false, finalSize);
-    }
-  }, [
-    debouncedDimensions,
-    isAvatar,
-    updateElementSize,
-    containerRef,
-    referenceDimensions,
-  ]);
-
-  useEffect(() => {
-    if (isAvatar && projectData?.scenes[0].avatar?.position) {
-      const pos = projectData.scenes[0].avatar.position;
-      setPosition({
-        x: (pos.x / referenceDimensions.width) * 100,
-        y: (pos.y / referenceDimensions.height) * 100,
-      });
-    } else if (!isAvatar && projectData?.scenes[0].background?.position) {
-      const pos = projectData.scenes[0].background.position;
-      setPosition({
-        x: (pos.x / referenceDimensions.width) * 100,
-        y: (pos.y / referenceDimensions.height) * 100,
+      updateElementPosition(currentElement.id, isAvatar ?? false, {
+        x: finalX,
+        y: finalY,
       });
     }
-  }, [isAvatar, projectData, referenceDimensions]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedPosition, currentElement?.id, referenceDimensions]);
+
+  useEffect(() => {
+    if (!debouncedDimensions || !currentElement?.id) return;
+
+    const finalSize = {
+      width: percentToPxForFinal(
+        debouncedDimensions.width,
+        referenceDimensions.width
+      ),
+      height: percentToPxForFinal(
+        debouncedDimensions.height,
+        referenceDimensions.height
+      ),
+    };
+
+    updateElementSize(currentElement.id, isAvatar ?? false, finalSize);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedDimensions, currentElement?.id, referenceDimensions]);
 
   const handleMouseDown = (e: React.MouseEvent<HTMLImageElement>) => {
     if (resizing) return;

--- a/src/components/project-editor/header/index.tsx
+++ b/src/components/project-editor/header/index.tsx
@@ -37,6 +37,7 @@ const ProjectHeader = () => {
     }
   };
   useEffect(() => {
+    resetProjectData();
     const loadProjects = async () => {
       try {
         const data = await fetchProjects(project);
@@ -50,7 +51,7 @@ const ProjectHeader = () => {
         alert(err);
       }
     };
-    resetProjectData();
+
     loadProjects();
   }, [setProjectData, resetProjectData, project]);
 
@@ -70,7 +71,6 @@ const ProjectHeader = () => {
       });
     }
   };
-
   const handleSaveProjectTitle = async () => {
     if (isEdit) {
       try {

--- a/src/components/project-editor/scriptVeiwPort/index.tsx
+++ b/src/components/project-editor/scriptVeiwPort/index.tsx
@@ -134,7 +134,7 @@ function VideoViewPortComponent({ aspectRatio }: { aspectRatio: string }) {
         {background && (
           <S.SelectedBackgroundImage
             aspectRatio={aspectRatio}
-            src={background.fileUrl}
+            src={background.fileId}
             alt={background.name}
             style={{
               transform,
@@ -146,7 +146,7 @@ function VideoViewPortComponent({ aspectRatio }: { aspectRatio: string }) {
         {avatar && (
           <S.SelectedAvatarImage
             aspectRatio={aspectRatio}
-            src={avatar.fileUrl}
+            src={avatar.fileId}
             autoPlay
             style={{
               transform: avatarTransform,

--- a/src/routes/_projectSideBarLayout/$project/avatar/index.tsx
+++ b/src/routes/_projectSideBarLayout/$project/avatar/index.tsx
@@ -16,7 +16,7 @@ export const Route = createFileRoute('/_projectSideBarLayout/$project/avatar/')(
 );
 
 function RouteComponent() {
-  const { projectData, updateAvatar, resetAvatar } = useProjectEditorStore();
+  const { projectData, updateAvatar } = useProjectEditorStore();
   const { aspectRatio } = useAspectRatioStore();
   const [selectedAvatarTemplateIndex, setSelectedAvatarTemplateIndex] =
     useState(-1);
@@ -25,55 +25,71 @@ function RouteComponent() {
   const backgroundRef = useRef<HTMLDivElement>(null);
   const debouncedAvatarIndex = useDebounce(selectedAvatarTemplateIndex, 1000);
 
+  // 초기 선택된 아바타 복원
   useEffect(() => {
-    if (!templateList) return;
+    const avatarFileId = projectData?.scenes?.[0]?.avatar?.fileId;
 
-    const template = templateList.data[selectedAvatarTemplateIndex] || null;
-    if (!template) {
-      resetAvatar();
-    } else {
-      updateAvatar(template.data.avatar);
+    if (!templateList?.data || !avatarFileId) return;
+
+    const savedIndex = templateList.data.findIndex(
+      (template) => template.data.avatar.fileUrl === avatarFileId
+    );
+
+    if (savedIndex !== -1 && savedIndex !== selectedAvatarTemplateIndex) {
+      setSelectedAvatarTemplateIndex(savedIndex);
     }
-  }, [templateList, selectedAvatarTemplateIndex, resetAvatar, updateAvatar]);
+  }, [projectData?.scenes, templateList?.data, selectedAvatarTemplateIndex]);
 
-  const selectedAvatarTemplate = useMemo(() => {
-    if (!templateList || selectedAvatarTemplateIndex === -1) {
-      return null;
-    }
-    return templateList.data[selectedAvatarTemplateIndex].data.avatar;
-  }, [templateList, selectedAvatarTemplateIndex]);
-
+  // 아바타 업데이트
   useEffect(() => {
-    if (!templateList || !projectData || !debouncedAvatarIndex) return;
+    if (selectedAvatarTemplateIndex === -1) return;
 
-    const currentTemplate = templateList.data[debouncedAvatarIndex];
+    const selectedTemplate = templateList?.data[selectedAvatarTemplateIndex];
+    if (!selectedTemplate) return;
 
+    updateAvatar(selectedTemplate.data.avatar);
+  }, [selectedAvatarTemplateIndex, templateList?.data, updateAvatar]);
+
+  // 서버 업데이트 - 디바운스 적용
+  useEffect(() => {
     if (
-      currentTemplate &&
-      selectedAvatarTemplateIndex === debouncedAvatarIndex
-    ) {
+      !projectData?.id ||
+      !debouncedAvatarIndex ||
+      debouncedAvatarIndex === -1
+    )
       return;
-    }
+    if (!templateList?.data[debouncedAvatarIndex]) return;
 
-    const upDateProjectImage = async () => {
+    const sceneId = projectData.scenes?.[0]?.id;
+
+    const updateProjectImage = async () => {
       try {
         await patchProjectAvatarImage(
           projectData.id,
-          projectData.scenes[0].id,
-          currentTemplate.data.avatar
+          sceneId,
+          templateList.data[debouncedAvatarIndex].data.avatar
         );
       } catch (error) {
         // eslint-disable-next-line no-console
-        console.log(`아바타 업데이트에 실패했습니다: ${error}`);
+        console.error(`아바타 업데이트에 실패했습니다: ${error}`);
       }
     };
-    upDateProjectImage();
+
+    updateProjectImage();
   }, [
-    projectData,
-    templateList,
-    selectedAvatarTemplateIndex,
     debouncedAvatarIndex,
+    projectData?.id,
+    projectData?.scenes,
+    templateList?.data,
   ]);
+
+  // 선택된 아바타 템플릿 메모이제이션
+  const selectedAvatarTemplate = useMemo(() => {
+    if (!templateList?.data || selectedAvatarTemplateIndex === -1) {
+      return null;
+    }
+    return templateList.data[selectedAvatarTemplateIndex].data.avatar;
+  }, [templateList?.data, selectedAvatarTemplateIndex]);
 
   const handleAvatarTemplateImage = (idx: number) => {
     setSelectedAvatarTemplateIndex(idx);
@@ -86,7 +102,7 @@ function RouteComponent() {
   return (
     <S.AvatarContainer>
       <S.AvatarMain>
-        {selectedAvatarTemplate && selectedAvatarTemplate.fileUrl && (
+        {selectedAvatarTemplate && (
           <DragImage
             aspectRatio={aspectRatio}
             imgSrc={selectedAvatarTemplate.fileUrl}

--- a/src/routes/_projectSideBarLayout/$project/avatar/index.tsx
+++ b/src/routes/_projectSideBarLayout/$project/avatar/index.tsx
@@ -5,9 +5,8 @@ import { useTemplates } from '@/hook/useTemplateList';
 import useAspectRatioStore from '@/store/useAspectRatioStore';
 import useProjectEditorStore from '@/store/useProjectEditorStore';
 import theme from '@/styles/theme';
-import { TemplateImage } from '@/types/template';
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useMemo } from 'react';
 import styled from 'styled-components';
 
 export const Route = createFileRoute('/_projectSideBarLayout/$project/avatar/')(
@@ -17,21 +16,42 @@ export const Route = createFileRoute('/_projectSideBarLayout/$project/avatar/')(
 );
 
 function RouteComponent() {
-  const { projectData, updateAvatar } = useProjectEditorStore();
+  const { projectData, updateAvatar, resetAvatar } = useProjectEditorStore();
   const { aspectRatio } = useAspectRatioStore();
-  const [selectedAvatarTemplate, setSelectedAvatarTemplate] =
-    useState<TemplateImage | null>(projectData?.scenes[0].avatar || null);
+  const [selectedAvatarTemplateIndex, setSelectedAvatarTemplateIndex] =
+    useState(-1);
   const { templatesQuery } = useTemplates();
   const { data: templateList, isLoading } = templatesQuery;
   const backgroundRef = useRef<HTMLDivElement>(null);
-  const avatar = projectData?.scenes[0].avatar;
-  const debouncedAvatar = useDebounce(avatar, 1000);
+  const debouncedAvatarIndex = useDebounce(selectedAvatarTemplateIndex, 1000);
 
   useEffect(() => {
-    if (!projectData || !debouncedAvatar) return;
+    if (!templateList) return;
 
-    const currentAvatar = projectData.scenes[0].avatar;
-    if (currentAvatar && currentAvatar === debouncedAvatar) {
+    const template = templateList.data[selectedAvatarTemplateIndex] || null;
+    if (!template) {
+      resetAvatar();
+    } else {
+      updateAvatar(template.data.avatar);
+    }
+  }, [templateList, selectedAvatarTemplateIndex, resetAvatar, updateAvatar]);
+
+  const selectedAvatarTemplate = useMemo(() => {
+    if (!templateList || selectedAvatarTemplateIndex === -1) {
+      return null;
+    }
+    return templateList.data[selectedAvatarTemplateIndex].data.avatar;
+  }, [templateList, selectedAvatarTemplateIndex]);
+
+  useEffect(() => {
+    if (!templateList || !projectData || !debouncedAvatarIndex) return;
+
+    const currentTemplate = templateList.data[debouncedAvatarIndex];
+
+    if (
+      currentTemplate &&
+      selectedAvatarTemplateIndex === debouncedAvatarIndex
+    ) {
       return;
     }
 
@@ -40,26 +60,29 @@ function RouteComponent() {
         await patchProjectAvatarImage(
           projectData.id,
           projectData.scenes[0].id,
-          debouncedAvatar
+          currentTemplate.data.avatar
         );
       } catch (error) {
         // eslint-disable-next-line no-console
-        console.log(`이미지 업로드에 실패했습니다: ${error}`);
+        console.log(`아바타 업데이트에 실패했습니다: ${error}`);
       }
     };
     upDateProjectImage();
-  }, [projectData, debouncedAvatar]);
+  }, [
+    projectData,
+    templateList,
+    selectedAvatarTemplateIndex,
+    debouncedAvatarIndex,
+  ]);
 
-  const handleAvatarTemplateImage = (template: TemplateImage) => {
-    if (template) {
-      setSelectedAvatarTemplate(template);
-      updateAvatar(template);
-    }
+  const handleAvatarTemplateImage = (idx: number) => {
+    setSelectedAvatarTemplateIndex(idx);
   };
 
   if (isLoading) {
     return <div>로딩중 </div>;
   }
+
   return (
     <S.AvatarContainer>
       <S.AvatarMain>
@@ -81,12 +104,14 @@ function RouteComponent() {
           </S.LabelSection>
 
           <S.AvatarTemplateList>
-            {templateList?.data.map((template) => (
+            {templateList?.data.map((template, idx) => (
               <S.AvatarTemplateCard
-                onClick={() => handleAvatarTemplateImage(template.data.avatar)}
+                onClick={() => handleAvatarTemplateImage(idx)}
                 key={template.data.avatar.id}>
                 <S.AvatarTemplateImg
-                  isSelected={selectedAvatarTemplate?.id === template.id}
+                  isSelected={
+                    selectedAvatarTemplate?.id === template.data.avatar.id
+                  }
                   src={template.data.avatar.fileUrl}
                   autoPlay={true}
                 />
@@ -98,6 +123,7 @@ function RouteComponent() {
     </S.AvatarContainer>
   );
 }
+
 const S = {
   AvatarContainer: styled.div`
     width: 100%;

--- a/src/routes/_projectSideBarLayout/$project/background/index.tsx
+++ b/src/routes/_projectSideBarLayout/$project/background/index.tsx
@@ -24,8 +24,7 @@ export const Route = createFileRoute(
 });
 
 function RouteComponent() {
-  const { projectData, updateBackground, resetBackground } =
-    useProjectEditorStore();
+  const { projectData, updateBackground } = useProjectEditorStore();
 
   const { templatesQuery } = useTemplates();
   const { data: templateList, isLoading } = templatesQuery;
@@ -40,73 +39,85 @@ function RouteComponent() {
   const inputRef = useRef<HTMLInputElement>(null);
   const backgroundRef = useRef<HTMLDivElement>(null);
 
+  // 초기 템플릿 이미지 설정
   useEffect(() => {
-    if (templateList) {
-      setTemplateImages((prevBackgrounds) => {
-        const newBackgrounds = templateList.data
-          .map((template) => template.data.background)
-          .filter((bg) => bg && !prevBackgrounds.includes(bg));
+    if (!templateList?.data) return;
+    const backgrounds = templateList.data.map(
+      (template) => template.data.background
+    );
+    setTemplateImages(backgrounds);
+  }, [templateList?.data]);
 
-        return [...prevBackgrounds, ...newBackgrounds];
-      });
-    }
-  }, [templateList]);
-
+  // 초기 선택된 배경 복원
   useEffect(() => {
-    if (!templateList) return;
+    const backgroundFileId = projectData?.scenes[0]?.background?.fileId;
 
-    const template = templateList.data[selectedTemplateBgIndex] || null;
-    if (!template) {
-      resetBackground();
-    } else {
-      updateBackground(template.data.background);
+    if (!templateImages.length || !backgroundFileId) return;
+
+    const savedIndex = templateImages.findIndex(
+      (bg) => bg.fileUrl === backgroundFileId
+    );
+
+    if (savedIndex !== -1 && savedIndex !== selectedTemplateBgIndex) {
+      setSelectedTemplateBgIndex(savedIndex);
     }
-  }, [
-    templateList,
-    selectedTemplateBgIndex,
-    resetBackground,
-    updateBackground,
-  ]);
+  }, [projectData?.scenes, templateImages, selectedTemplateBgIndex]);
 
-  const selectedBackgroundTemplate = useMemo(() => {
-    if (!templateList || selectedTemplateBgIndex == -1) {
-      return null;
-    }
-    return templateList.data[selectedTemplateBgIndex].data.background;
-  }, [templateList, selectedTemplateBgIndex]);
-
+  // 배경 업데이트
   useEffect(() => {
-    if (!templateList || !projectData || !debouncedTemplateBgIndex) return;
-
-    const currentTemplate = templateList.data[debouncedTemplateBgIndex];
-
     if (
-      currentTemplate &&
-      selectedTemplateBgIndex === debouncedTemplateBgIndex
-    ) {
+      selectedTemplateBgIndex === -1 ||
+      !templateImages[selectedTemplateBgIndex]
+    )
       return;
-    }
+    updateBackground(templateImages[selectedTemplateBgIndex]);
+  }, [selectedTemplateBgIndex, templateImages, updateBackground]);
+
+  // 서버 업데이트 - 디바운스 적용
+  useEffect(() => {
+    if (
+      !projectData?.id ||
+      !projectData?.scenes[0]?.id ||
+      debouncedTemplateBgIndex === undefined ||
+      debouncedTemplateBgIndex === -1
+    )
+      return;
+
+    const selectedTemplate = templateImages[debouncedTemplateBgIndex];
+    if (!selectedTemplate) return;
 
     const upDateProjectImage = async () => {
       try {
         await patchProjectBackgroundImage(
           projectData.id,
           projectData.scenes[0].id,
-          currentTemplate.data.background
+          selectedTemplate
         );
       } catch (error) {
         // eslint-disable-next-line no-console
-        console.log(`이미지 업로드에 실패했습니다${error}`);
+        console.error(`이미지 업로드에 실패했습니다: ${error}`);
       }
     };
 
     upDateProjectImage();
+    const projectSceneId = projectData?.scenes?.[0]?.id;
+    const projectId = projectData?.id;
+
+    if (!projectId || !projectSceneId) return;
   }, [
-    projectData,
-    templateList,
-    selectedTemplateBgIndex,
     debouncedTemplateBgIndex,
+    projectData?.id,
+    projectData?.scenes,
+    templateImages,
   ]);
+
+  // selectedBackgroundTemplate 계산 로직 수정
+  const selectedBackgroundTemplate = useMemo(() => {
+    if (!templateImages || selectedTemplateBgIndex === -1) {
+      return null;
+    }
+    return templateImages[selectedTemplateBgIndex];
+  }, [templateImages, selectedTemplateBgIndex]);
 
   const handleBakcgroundTemplateImage = (idx: number) => {
     setSelectedTemplateBgIndex(idx);

--- a/src/routes/_projectSideBarLayout/$project/background/index.tsx
+++ b/src/routes/_projectSideBarLayout/$project/background/index.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import DropDown from '@/components/common/dropdown';
 import theme from '@/styles/theme';
 import { createFileRoute } from '@tanstack/react-router';
@@ -26,15 +26,15 @@ export const Route = createFileRoute(
 function RouteComponent() {
   const { projectData, updateBackground, resetBackground } =
     useProjectEditorStore();
+
   const { templatesQuery } = useTemplates();
   const { data: templateList, isLoading } = templatesQuery;
+  const [selectedTemplateBgIndex, setSelectedTemplateBgIndex] = useState(-1);
+  const debouncedTemplateBgIndex = useDebounce(selectedTemplateBgIndex, 1000);
+
   const { aspectRatio, setAspectRatio } = useAspectRatioStore();
-  const [selectedBackgroundTemplate, setSelectedBackgroundTemplate] =
-    useState<TemplateImage | null>(projectData?.scenes[0].background || null);
   const [templateImages, setTemplateImages] = useState<TemplateImage[]>([]);
 
-  const media = projectData?.scenes[0]?.background;
-  const debouncedBackground = useDebounce(media, 1000);
   const generateId = nanoid(10);
 
   const inputRef = useRef<HTMLInputElement>(null);
@@ -53,17 +53,37 @@ function RouteComponent() {
   }, [templateList]);
 
   useEffect(() => {
-    if (selectedBackgroundTemplate) {
-      updateBackground(selectedBackgroundTemplate);
+    if (!templateList) return;
+
+    const template = templateList.data[selectedTemplateBgIndex] || null;
+    if (!template) {
+      resetBackground();
+    } else {
+      updateBackground(template.data.background);
     }
-  }, [selectedBackgroundTemplate, updateBackground]);
+  }, [
+    templateList,
+    selectedTemplateBgIndex,
+    resetBackground,
+    updateBackground,
+  ]);
+
+  const selectedBackgroundTemplate = useMemo(() => {
+    if (!templateList || selectedTemplateBgIndex == -1) {
+      return null;
+    }
+    return templateList.data[selectedTemplateBgIndex].data.background;
+  }, [templateList, selectedTemplateBgIndex]);
 
   useEffect(() => {
-    if (!debouncedBackground || !projectData) return;
+    if (!templateList || !projectData || !debouncedTemplateBgIndex) return;
 
-    const currentBackground = projectData.scenes[0].background;
+    const currentTemplate = templateList.data[debouncedTemplateBgIndex];
 
-    if (currentBackground && currentBackground === debouncedBackground) {
+    if (
+      currentTemplate &&
+      selectedTemplateBgIndex === debouncedTemplateBgIndex
+    ) {
       return;
     }
 
@@ -72,7 +92,7 @@ function RouteComponent() {
         await patchProjectBackgroundImage(
           projectData.id,
           projectData.scenes[0].id,
-          debouncedBackground
+          currentTemplate.data.background
         );
       } catch (error) {
         // eslint-disable-next-line no-console
@@ -81,16 +101,15 @@ function RouteComponent() {
     };
 
     upDateProjectImage();
-  }, [projectData, debouncedBackground]);
+  }, [
+    projectData,
+    templateList,
+    selectedTemplateBgIndex,
+    debouncedTemplateBgIndex,
+  ]);
 
-  const handleBakcgroundTemplateImage = (template: TemplateImage | null) => {
-    if (template) {
-      setSelectedBackgroundTemplate(template);
-      updateBackground(template);
-    } else {
-      setSelectedBackgroundTemplate(null);
-      resetBackground();
-    }
+  const handleBakcgroundTemplateImage = (idx: number) => {
+    setSelectedTemplateBgIndex(idx);
   };
 
   const handleInput = () => {
@@ -133,13 +152,18 @@ function RouteComponent() {
     };
     reader.readAsDataURL(file);
   };
+
   if (isLoading) {
     return <div>로딩중</div>;
   }
+
+  const isTemplabeBgSelected =
+    selectedBackgroundTemplate && selectedBackgroundTemplate.fileUrl;
+
   return (
     <S.BackgroundContainer>
       <S.BackgroundMain>
-        {selectedBackgroundTemplate && selectedBackgroundTemplate.fileUrl && (
+        {isTemplabeBgSelected && (
           <DragImage
             aspectRatio={aspectRatio}
             imgSrc={selectedBackgroundTemplate.fileUrl}
@@ -182,9 +206,9 @@ function RouteComponent() {
           </S.LabelSection>
 
           <S.BackgroundTemplateList>
-            {templateImages.map((template) => (
+            {templateImages.map((template, idx) => (
               <S.BackgroundTemplateCard
-                onClick={() => handleBakcgroundTemplateImage(template)}
+                onClick={() => handleBakcgroundTemplateImage(idx)}
                 key={template.id}>
                 <S.BackgroundTemplateImg
                   isSelected={selectedBackgroundTemplate?.id === template.id}
@@ -197,7 +221,7 @@ function RouteComponent() {
 
           <S.BackgroundButtonSection>
             <S.BackgroundButton
-              onClick={() => handleBakcgroundTemplateImage(null)}>
+              onClick={() => handleBakcgroundTemplateImage(-1)}>
               <DeleteBackgroundIcon />
               배경 제거
             </S.BackgroundButton>

--- a/src/store/useProjectEditorStore.ts
+++ b/src/store/useProjectEditorStore.ts
@@ -33,7 +33,7 @@ const useProjectEditorStore = create<ProjectState>((set) => ({
                   name: avatar.name,
                   priority: avatar.priority,
                   type: avatar.type,
-                  fileUrl: avatar.fileUrl,
+                  fileId: avatar.fileId,
                   position: { x: 0, y: 0 },
                   size: avatar.size,
                   scale: 1,
@@ -48,7 +48,7 @@ const useProjectEditorStore = create<ProjectState>((set) => ({
                   name: background.name,
                   priority: background.priority,
                   type: background.type,
-                  fileUrl: background.fileUrl,
+                  fileId: background.fileId,
                   position: { x: 0, y: 0 },
                   size: background.size,
                   scale: 1,
@@ -74,7 +74,7 @@ const useProjectEditorStore = create<ProjectState>((set) => ({
         name: template.name,
         priority: template.priority,
         type: template.type,
-        fileUrl: template.fileUrl,
+        fileId: template.fileUrl,
         position: { x: 0, y: 0 },
         size: template.size,
         scale: 1,
@@ -106,7 +106,7 @@ const useProjectEditorStore = create<ProjectState>((set) => ({
         name: template.name,
         priority: template.priority,
         type: template.type,
-        fileUrl: template.fileUrl,
+        fileId: template.fileUrl,
         position: { x: 0, y: 0 },
         size: template.size,
         scale: 1,
@@ -129,55 +129,61 @@ const useProjectEditorStore = create<ProjectState>((set) => ({
     });
   },
 
-  updateElementPosition: (isAvatar: boolean, newPosition: Position) => {
+  updateElementPosition: (
+    elementId: number,
+    isAvatar: boolean,
+    newPosition: Position
+  ) => {
     set((state) => {
       if (!state.projectData || !state.projectData.scenes.length) return state;
 
       return {
         projectData: {
           ...state.projectData,
-          scenes: state.projectData.scenes.map((scene, index) =>
-            index === 0
-              ? {
-                  ...scene,
-                  [isAvatar ? 'avatar' : 'background']: scene[
-                    isAvatar ? 'avatar' : 'background'
-                  ]
-                    ? {
-                        ...scene[isAvatar ? 'avatar' : 'background'],
-                        position: newPosition,
-                      }
-                    : null,
-                }
-              : scene
-          ),
+          scenes: state.projectData.scenes.map((scene) => {
+            const element = isAvatar ? scene.avatar : scene.background;
+
+            if (element && element.id === elementId) {
+              return {
+                ...scene,
+                [isAvatar ? 'avatar' : 'background']: {
+                  ...element,
+                  position: newPosition,
+                },
+              };
+            }
+            return scene;
+          }),
         },
       };
     });
   },
 
-  updateElementSize: (isAvatar: boolean, newSize: TemplateSize) => {
+  updateElementSize: (
+    elementId: number,
+    isAvatar: boolean,
+    newSize: TemplateSize
+  ) => {
     set((state) => {
       if (!state.projectData || !state.projectData.scenes.length) return state;
 
       return {
         projectData: {
           ...state.projectData,
-          scenes: state.projectData.scenes.map((scene, index) =>
-            index === 0
-              ? {
-                  ...scene,
-                  [isAvatar ? 'avatar' : 'background']: scene[
-                    isAvatar ? 'avatar' : 'background'
-                  ]
-                    ? {
-                        ...scene[isAvatar ? 'avatar' : 'background'],
-                        size: newSize,
-                      }
-                    : null,
-                }
-              : scene
-          ),
+          scenes: state.projectData.scenes.map((scene) => {
+            const element = isAvatar ? scene.avatar : scene.background;
+
+            if (element && element.id === elementId) {
+              return {
+                ...scene,
+                [isAvatar ? 'avatar' : 'background']: {
+                  ...element,
+                  size: newSize,
+                },
+              };
+            }
+            return scene;
+          }),
         },
       };
     });

--- a/src/store/useProjectEditorStore.ts
+++ b/src/store/useProjectEditorStore.ts
@@ -201,6 +201,24 @@ const useProjectEditorStore = create<ProjectState>((set) => ({
       };
     });
   },
+  resetAvatar: () => {
+    set((state) => {
+      if (!state.projectData || state.projectData.scenes.length === 0)
+        return state;
+
+      return {
+        projectData: {
+          ...state.projectData,
+          scenes: [
+            {
+              ...state.projectData.scenes[0],
+              avatar: null,
+            },
+          ],
+        },
+      };
+    });
+  },
   updateTranscripts: (
     sceneId: number,
     transcriptId: number,

--- a/src/types/projectData.ts
+++ b/src/types/projectData.ts
@@ -10,7 +10,7 @@ export interface ImageType {
   name: string;
   priority: number;
   type: string;
-  fileUrl: string;
+  fileId: string;
   position: Position;
   scale: number;
   viewport: number[];
@@ -72,8 +72,16 @@ export interface ProjectState {
   setSuggestProjectData: (newData: SuggestProjectData) => void;
   updateBackground: (template: TemplateImage) => void;
   updateAvatar: (template: TemplateImage) => void;
-  updateElementPosition: (isAvatar: boolean, newPosition: Position) => void;
-  updateElementSize: (isAvatar: boolean, newSize: TemplateSize) => void;
+  updateElementPosition: (
+    elementId: number,
+    isAvatar: boolean,
+    newPosition: Position
+  ) => void;
+  updateElementSize: (
+    elementId: number,
+    isAvatar: boolean,
+    newSize: TemplateSize
+  ) => void;
   resetBackground: () => void;
   resetAvatar: () => void;
   updateTranscripts: (

--- a/src/types/projectData.ts
+++ b/src/types/projectData.ts
@@ -75,6 +75,7 @@ export interface ProjectState {
   updateElementPosition: (isAvatar: boolean, newPosition: Position) => void;
   updateElementSize: (isAvatar: boolean, newSize: TemplateSize) => void;
   resetBackground: () => void;
+  resetAvatar: () => void;
   updateTranscripts: (
     sceneId: number,
     transcriptId: number,


### PR DESCRIPTION
## ➕ 이슈 링크

- 이슈 넘버 #[issue_number]

## 🔎 작업 내용

- 기존 fileUrl로 오던 이미지가 fileId로 변경됨에 따라, index 참조 형식으로 서버에 저장 및 이미지 로드하도록 방식 변경
- 서버 데이터에 저장 된 프로젝트 배경, 아바타 이미지를 선택된 상태로 랜더링 되지 않는 현상 수정

## 💾 이미지 첨부

![image](https://github.com/user-attachments/assets/40d83770-790a-4f44-830d-1cef8a9db0f9)

## 🔧 리뷰 요구사항

- 리뷰 요구사항을 작성해주세요
