### PR TITLE
hotfix: 배경화면 선택 페이지에서 발생한 무한루프,  불필요한 useEffect 의존성 객체 수정

### DIFF
--- a/src/components/project-editor/dragImage/index.tsx
+++ b/src/components/project-editor/dragImage/index.tsx
@@ -93,10 +93,23 @@ function DragImage({
       Math.abs(position.x - newPosition.x) > 0.1 ||
       Math.abs(position.y - newPosition.y) > 0.1
     ) {
-      setPosition(newPosition);
+      setPosition((prev) => {
+        if (
+          Math.abs(prev.x - newPosition.x) < 0.1 &&
+          Math.abs(prev.y - newPosition.y) < 0.1
+        ) {
+          return prev;
+        }
+        return newPosition;
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentElement?.position, referenceDimensions, projectData]);
+  }, [
+    currentElement?.position?.x,
+    currentElement?.position?.y,
+    referenceDimensions.width,
+    referenceDimensions.height,
+  ]);
 
   useEffect(() => {
     if (!debouncedPosition || !currentElement?.id) return;
@@ -104,9 +117,11 @@ function DragImage({
     const finalX = (debouncedPosition.x / 100) * referenceDimensions.width;
     const finalY = (debouncedPosition.y / 100) * referenceDimensions.height;
 
+    // 현재 위치와 새로운 위치가 크게 다를 때만 업데이트
+    const threshold = 1;
     if (
-      Math.abs(currentElement.position.x - finalX) > 1 ||
-      Math.abs(currentElement.position.y - finalY) > 1
+      Math.abs(currentElement.position.x - finalX) > threshold ||
+      Math.abs(currentElement.position.y - finalY) > threshold
     ) {
       updateElementPosition(currentElement.id, isAvatar ?? false, {
         x: finalX,
@@ -114,7 +129,12 @@ function DragImage({
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedPosition, currentElement?.id, referenceDimensions]);
+  }, [
+    debouncedPosition,
+    currentElement?.id,
+    referenceDimensions.width,
+    referenceDimensions.height,
+  ]);
 
   useEffect(() => {
     if (!debouncedDimensions || !currentElement?.id) return;
@@ -130,9 +150,20 @@ function DragImage({
       ),
     };
 
-    updateElementSize(currentElement.id, isAvatar ?? false, finalSize);
+    // 현재 크기와 새로운 크기가 크게 다를 때만 업데이트
+    if (
+      Math.abs(currentElement.size.width - finalSize.width) > 1 ||
+      Math.abs(currentElement.size.height - finalSize.height) > 1
+    ) {
+      updateElementSize(currentElement.id, isAvatar ?? false, finalSize);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedDimensions, currentElement?.id, referenceDimensions]);
+  }, [
+    debouncedDimensions,
+    currentElement?.id,
+    referenceDimensions.width,
+    referenceDimensions.height,
+  ]);
 
   const handleMouseDown = (e: React.MouseEvent<HTMLImageElement>) => {
     if (resizing) return;

--- a/src/routes/_projectSideBarLayout/$project/background/index.tsx
+++ b/src/routes/_projectSideBarLayout/$project/background/index.tsx
@@ -50,41 +50,47 @@ function RouteComponent() {
 
   // 초기 선택된 배경 복원
   useEffect(() => {
-    const backgroundFileId = projectData?.scenes[0]?.background?.fileId;
+    if (!templateImages.length || !projectData?.scenes[0]?.background?.fileId)
+      return;
 
-    if (!templateImages.length || !backgroundFileId) return;
-
+    const backgroundFileId = projectData.scenes[0].background.fileId;
     const savedIndex = templateImages.findIndex(
       (bg) => bg.fileUrl === backgroundFileId
     );
 
-    if (savedIndex !== -1 && savedIndex !== selectedTemplateBgIndex) {
+    if (savedIndex !== -1 && selectedTemplateBgIndex === -1) {
       setSelectedTemplateBgIndex(savedIndex);
     }
-  }, [projectData?.scenes, templateImages, selectedTemplateBgIndex]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectData?.scenes[0]?.background?.fileId, templateImages]);
 
   // 배경 업데이트
-  useEffect(() => {
+  const selectedBackgroundTemplate = useMemo(() => {
     if (
       selectedTemplateBgIndex === -1 ||
       !templateImages[selectedTemplateBgIndex]
-    )
-      return;
-    updateBackground(templateImages[selectedTemplateBgIndex]);
-  }, [selectedTemplateBgIndex, templateImages, updateBackground]);
+    ) {
+      return null;
+    }
+    return templateImages[selectedTemplateBgIndex];
+  }, [selectedTemplateBgIndex, templateImages]);
+
+  useEffect(() => {
+    if (!selectedBackgroundTemplate) return;
+    updateBackground(selectedBackgroundTemplate);
+  }, [selectedBackgroundTemplate, updateBackground]);
 
   // 서버 업데이트 - 디바운스 적용
   useEffect(() => {
     if (
       !projectData?.id ||
       !projectData?.scenes[0]?.id ||
-      debouncedTemplateBgIndex === undefined ||
-      debouncedTemplateBgIndex === -1
+      debouncedTemplateBgIndex === -1 ||
+      !templateImages[debouncedTemplateBgIndex]
     )
       return;
 
     const selectedTemplate = templateImages[debouncedTemplateBgIndex];
-    if (!selectedTemplate) return;
 
     const upDateProjectImage = async () => {
       try {
@@ -100,26 +106,17 @@ function RouteComponent() {
     };
 
     upDateProjectImage();
-    const projectSceneId = projectData?.scenes?.[0]?.id;
-    const projectId = projectData?.id;
-
-    if (!projectId || !projectSceneId) return;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     debouncedTemplateBgIndex,
     projectData?.id,
-    projectData?.scenes,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    projectData?.scenes[0]?.id,
     templateImages,
   ]);
 
-  // selectedBackgroundTemplate 계산 로직 수정
-  const selectedBackgroundTemplate = useMemo(() => {
-    if (!templateImages || selectedTemplateBgIndex === -1) {
-      return null;
-    }
-    return templateImages[selectedTemplateBgIndex];
-  }, [templateImages, selectedTemplateBgIndex]);
-
   const handleBakcgroundTemplateImage = (idx: number) => {
+    if (idx === selectedTemplateBgIndex) return;
     setSelectedTemplateBgIndex(idx);
   };
 

--- a/src/store/useProjectEditorStore.ts
+++ b/src/store/useProjectEditorStore.ts
@@ -135,25 +135,35 @@ const useProjectEditorStore = create<ProjectState>((set) => ({
     newPosition: Position
   ) => {
     set((state) => {
-      if (!state.projectData || !state.projectData.scenes.length) return state;
+      if (!state.projectData?.scenes.length) return state;
+
+      const currentScene = state.projectData.scenes[0];
+      const element = isAvatar ? currentScene.avatar : currentScene.background;
+
+      if (!element || element.id !== elementId) return state;
+
+      // 현재 위치와 새 위치가 동일하면 업데이트하지 않음
+      if (
+        element.position.x === newPosition.x &&
+        element.position.y === newPosition.y
+      ) {
+        return state;
+      }
 
       return {
         projectData: {
           ...state.projectData,
-          scenes: state.projectData.scenes.map((scene) => {
-            const element = isAvatar ? scene.avatar : scene.background;
-
-            if (element && element.id === elementId) {
-              return {
-                ...scene,
-                [isAvatar ? 'avatar' : 'background']: {
-                  ...element,
-                  position: newPosition,
-                },
-              };
-            }
-            return scene;
-          }),
+          scenes: state.projectData.scenes.map((scene, index) =>
+            index === 0
+              ? {
+                  ...scene,
+                  [isAvatar ? 'avatar' : 'background']: {
+                    ...element,
+                    position: newPosition,
+                  },
+                }
+              : scene
+          ),
         },
       };
     });
@@ -165,25 +175,35 @@ const useProjectEditorStore = create<ProjectState>((set) => ({
     newSize: TemplateSize
   ) => {
     set((state) => {
-      if (!state.projectData || !state.projectData.scenes.length) return state;
+      if (!state.projectData?.scenes.length) return state;
+
+      const currentScene = state.projectData.scenes[0];
+      const element = isAvatar ? currentScene.avatar : currentScene.background;
+
+      if (!element || element.id !== elementId) return state;
+
+      // 현재 크기와 새 크기가 동일하면 업데이트하지 않음
+      if (
+        element.size.width === newSize.width &&
+        element.size.height === newSize.height
+      ) {
+        return state;
+      }
 
       return {
         projectData: {
           ...state.projectData,
-          scenes: state.projectData.scenes.map((scene) => {
-            const element = isAvatar ? scene.avatar : scene.background;
-
-            if (element && element.id === elementId) {
-              return {
-                ...scene,
-                [isAvatar ? 'avatar' : 'background']: {
-                  ...element,
-                  size: newSize,
-                },
-              };
-            }
-            return scene;
-          }),
+          scenes: state.projectData.scenes.map((scene, index) =>
+            index === 0
+              ? {
+                  ...scene,
+                  [isAvatar ? 'avatar' : 'background']: {
+                    ...element,
+                    size: newSize,
+                  },
+                }
+              : scene
+          ),
         },
       };
     });


### PR DESCRIPTION
## ➕ 이슈 링크

- 이슈 넘버 #99 

## 🔎 작업 내용

- useEffect에서 불필요한 의존성 객체를 수정했습니다만 린트 설정으로 인해 경고가 발생해 
`eslint-disable-next-line react-hooks/exhaustive-deps` 를 활용하여 린트 경고는 무시했습니다.

## 💾 이미지 첨부

- 스크린샷이나 레퍼런스를 추가해주세요

## 🔧 리뷰 요구사항

- 리뷰 요구사항을 작성해주세요
